### PR TITLE
Multi-agenda, and version upgrade/versions refactor

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,15 +49,19 @@ type intervalVersionCounts struct {
 // Set all activeNetParams fields since they don't change at runtime
 var templateInformation = &templateFields{
 	// BlockVersion params
-	BlockVersionEnforceThreshold: int(float64(activeNetParams.BlockEnforceNumRequired) / float64(activeNetParams.BlockUpgradeNumToCheck) * 100),
-	BlockVersionRejectThreshold:  int(float64(activeNetParams.BlockRejectNumRequired) / float64(activeNetParams.BlockUpgradeNumToCheck) * 100),
-	BlockVersionWindowLength:     activeNetParams.BlockUpgradeNumToCheck,
+	BlockVersionEnforceThreshold: int(float64(activeNetParams.BlockEnforceNumRequired) /
+		float64(activeNetParams.BlockUpgradeNumToCheck) * 100),
+	BlockVersionRejectThreshold: int(float64(activeNetParams.BlockRejectNumRequired) /
+		float64(activeNetParams.BlockUpgradeNumToCheck) * 100),
+	BlockVersionWindowLength: activeNetParams.BlockUpgradeNumToCheck,
 	// StakeVersion params
 	StakeVersionWindowLength: activeNetParams.StakeVersionInterval,
-	StakeVersionThreshold:    toFixed(float64(activeNetParams.StakeMajorityMultiplier)/float64(activeNetParams.StakeMajorityDivisor)*100, 0),
+	StakeVersionThreshold: toFixed(float64(activeNetParams.StakeMajorityMultiplier)/
+		float64(activeNetParams.StakeMajorityDivisor)*100, 0),
 	// RuleChange params
 	RuleChangeActivationQuorum: activeNetParams.RuleChangeActivationQuorum,
-	QuorumThreshold:            float64(activeNetParams.RuleChangeActivationQuorum) / float64(activeNetParams.RuleChangeActivationInterval*uint32(activeNetParams.TicketsPerBlock)) * 100,
+	QuorumThreshold: float64(activeNetParams.RuleChangeActivationQuorum) /
+		float64(activeNetParams.RuleChangeActivationInterval*uint32(activeNetParams.TicketsPerBlock)) * 100,
 }
 
 // updatetemplateInformation is called on startup and upon every block connected notification received.
@@ -109,7 +113,8 @@ func updatetemplateInformation(dcrdClient *dcrrpcclient.Client) {
 			if !ok {
 				// Had not found this block version yet
 				blockVersionsFound[stakeVersion.BlockVersion] = &blockVersions{}
-				blockVersionsFound[stakeVersion.BlockVersion].RollingWindowLookBacks = make([]int, templateInformation.BlockVersionWindowLength)
+				blockVersionsFound[stakeVersion.BlockVersion].RollingWindowLookBacks =
+					make([]int, templateInformation.BlockVersionWindowLength)
 				// Need to populate "back" to fill in values for previously missed window
 				for k := 0; k < elementNum; k++ {
 					blockVersionsFound[stakeVersion.BlockVersion].RollingWindowLookBacks[k] = 0
@@ -153,8 +158,9 @@ func updatetemplateInformation(dcrdClient *dcrrpcclient.Client) {
 		}
 	}
 
-	blocksIntoStakeVersionWindow := (templateInformation.BlockHeight - activeNetParams.StakeValidationHeight) % activeNetParams.StakeVersionInterval
-	// Request twice as many, so we can populate the rolling block version window's first
+	blocksIntoStakeVersionWindow := (templateInformation.BlockHeight - activeNetParams.StakeValidationHeight) %
+		activeNetParams.StakeVersionInterval
+	// Rolling stake version window's
 	heightstakeVersionResults, err := dcrdClient.GetStakeVersions(hash.String(),
 		int32(blocksIntoStakeVersionWindow))
 	if err != nil {
@@ -165,8 +171,8 @@ func updatetemplateInformation(dcrdClient *dcrrpcclient.Client) {
 		missedVotesStakeInterval += int(activeNetParams.TicketsPerBlock) - len(stakeVersionResult.Votes)
 	}
 
-	numberOfIntervals := 4
-	stakeVersionInfo, err := dcrdClient.GetStakeVersionInfo(int32(numberOfIntervals))
+	numberOfIntervalsToCheck := 4
+	stakeVersionInfo, err := dcrdClient.GetStakeVersionInfo(int32(numberOfIntervalsToCheck))
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/main.go
+++ b/main.go
@@ -278,6 +278,7 @@ func updatetemplateInformation(dcrdClient *dcrrpcclient.Client) {
 	// There may be no agendas for this vote version
 	if len(getVoteInfo.Agendas) == 0 {
 		fmt.Printf("No agendas for vote version %d\n", mostPopularVersion)
+		templateInformation.Agendas = []Agenda{}
 		return
 	}
 
@@ -295,13 +296,6 @@ func updatetemplateInformation(dcrdClient *dcrrpcclient.Client) {
 	templateInformation.Agendas = make([]Agenda, 0, len(getVoteInfo.Agendas))
 
 	for i := range getVoteInfo.Agendas {
-		// templateInformation.VotingStarted = getVoteInfo.Agendas[0].Status == "started"
-		// templateInformation.VotingDefined = getVoteInfo.Agendas[0].Status == "defined"
-		// templateInformation.VotingLockedin = getVoteInfo.Agendas[0].Status == "lockedin"
-		// templateInformation.VotingFailed = getVoteInfo.Agendas[0].Status == "failed"
-		// templateInformation.VotingActive = getVoteInfo.Agendas[0].Status == "active"
-		// templateInformation.QuorumAchieved = getVoteInfo.Agendas[0].QuorumProgress == 1
-
 		choiceIds := make([]string, len(getVoteInfo.Agendas[i].Choices))
 		choicePercentages := make([]float64, len(getVoteInfo.Agendas[i].Choices))
 		for i, choice := range getVoteInfo.Agendas[i].Choices {
@@ -318,6 +312,7 @@ func updatetemplateInformation(dcrdClient *dcrrpcclient.Client) {
 			QuorumAbstainedPercentage: toFixed(getVoteInfo.Agendas[i].Choices[0].Progress*100, 2),
 			ChoiceIDs:                 choiceIds,
 			ChoicePercentages:         choicePercentages,
+			StartHeight:               getVoteInfo.StartHeight,
 		})
 	}
 }

--- a/main.go
+++ b/main.go
@@ -89,13 +89,13 @@ func updatetemplateInformation(dcrdClient *dcrrpcclient.Client) {
 	//
 	// Request twice as many, so we can populate the rolling block version window's first
 	stakeVersionResults, err := dcrdClient.GetStakeVersions(hash.String(),
-		int32(templateInformation.BlockVersionWindowLength*2))
+		int32(activeNetParams.BlockUpgradeNumToCheck*2))
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
 	blockVersionsFound := make(map[int32]*blockVersions)
-	blockVersionsHeights := make([]int64, templateInformation.BlockVersionWindowLength)
+	blockVersionsHeights := make([]int64, activeNetParams.BlockUpgradeNumToCheck)
 	elementNum := 0
 
 	// The algorithm starts at the middle of the GetStakeVersionResults and decrements backwards toward
@@ -105,7 +105,7 @@ func updatetemplateInformation(dcrdClient *dcrrpcclient.Client) {
 	// and calculate that blocks rolling window results.
 	for i := len(stakeVersionResults.StakeVersions)/2 - 1; i >= 0; i-- {
 		// Calculate the last block element in the window
-		windowEnd := i + int(templateInformation.BlockVersionWindowLength)
+		windowEnd := i + int(activeNetParams.BlockUpgradeNumToCheck)
 		// blockVersionsHeights lets us have a correctly ordered list of blockheights for xaxis label
 		blockVersionsHeights[elementNum] = stakeVersionResults.StakeVersions[i].Height
 		// Define rolling window range for this current block (i)
@@ -118,7 +118,7 @@ func updatetemplateInformation(dcrdClient *dcrrpcclient.Client) {
 				theseBlockVersions = &blockVersions{}
 				blockVersionsFound[stakeVersion.BlockVersion] = theseBlockVersions
 				theseBlockVersions.RollingWindowLookBacks =
-					make([]int, templateInformation.BlockVersionWindowLength)
+					make([]int, activeNetParams.BlockUpgradeNumToCheck)
 				// Need to populate "back" to fill in values for previously missed window
 				for k := 0; k < elementNum; k++ {
 					theseBlockVersions.RollingWindowLookBacks[k] = 0
@@ -135,21 +135,23 @@ func updatetemplateInformation(dcrdClient *dcrrpcclient.Client) {
 	templateInformation.BlockVersions = blockVersionsFound
 
 	// Pick min block version (current version) out of most recent window
-	stakeVersionsWindow := stakeVersionResults.StakeVersions[:templateInformation.BlockVersionWindowLength]
+	stakeVersionsWindow := stakeVersionResults.StakeVersions[:activeNetParams.BlockUpgradeNumToCheck]
 	blockVersionsCounts := make(map[int32]int64)
 	for _, sv := range stakeVersionsWindow {
 		blockVersionsCounts[sv.BlockVersion] = blockVersionsCounts[sv.BlockVersion] + 1
 	}
 	var minBlockVersion, maxBlockVersion, popBlockVersion int32 = math.MaxInt32, -1, 0
-	popBlockVersionCount := int64(-1)
-	for v, c := range blockVersionsCounts {
+	for v := range blockVersionsCounts {
 		if v < minBlockVersion {
 			minBlockVersion = v
 		}
 		if v > maxBlockVersion {
 			maxBlockVersion = v
 		}
-		if c > popBlockVersionCount {
+	}
+	popBlockVersionCount := int64(-1)
+	for v, c := range blockVersionsCounts {
+		if c > popBlockVersionCount && v != minBlockVersion {
 			popBlockVersionCount = c
 			popBlockVersion = v
 		}
@@ -167,27 +169,34 @@ func updatetemplateInformation(dcrdClient *dcrrpcclient.Client) {
 	templateInformation.BlockVersionNext = minBlockVersion + 1
 	templateInformation.BlockVersionNextPercentage = toFixed(blockWinUpgradePct(blockVersionsCounts[minBlockVersion+1]), 2)
 
-	// Voting intervals
-	blocksIntoStakeVersionWindow := (templateInformation.BlockHeight - activeNetParams.StakeValidationHeight) %
+	if popBlockVersionCount > int64(activeNetParams.BlockEnforceNumRequired) {
+		templateInformation.BlockVersionSuccess = true
+	}
+
+	// Voting intervals ((height-4096) mod 2016)
+	blocksIntoStakeVersionInterval := (height - activeNetParams.StakeValidationHeight) %
 		activeNetParams.StakeVersionInterval
-	// Rolling stake version window's
-	heightstakeVersionResults, err := dcrdClient.GetStakeVersions(hash.String(),
-		int32(blocksIntoStakeVersionWindow))
+	// Stake versions per block in current voting interval (getstakeversions hash blocksIntoInterval)
+	intervalStakeVersions, err := dcrdClient.GetStakeVersions(hash.String(),
+		int32(blocksIntoStakeVersionInterval))
 	if err != nil {
 		fmt.Println(err)
 	}
+	// Tally missed votes so far in this interval
 	missedVotesStakeInterval := 0
-	for _, stakeVersionResult := range heightstakeVersionResults.StakeVersions {
+	for _, stakeVersionResult := range intervalStakeVersions.StakeVersions {
 		missedVotesStakeInterval += int(activeNetParams.TicketsPerBlock) - len(stakeVersionResult.Votes)
 	}
 
+	// Vote tallies for previous intervals (getstakeversioninfo 4)
 	numberOfIntervalsToCheck := 4
 	stakeVersionInfo, err := dcrdClient.GetStakeVersionInfo(int32(numberOfIntervalsToCheck))
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
-	if len(stakeVersionInfo.Intervals) == 0 {
+	numIntervals := len(stakeVersionInfo.Intervals)
+	if numIntervals == 0 {
 		fmt.Println("StakeVersion info did not return usable information, intervals empty")
 		return
 	}
@@ -197,61 +206,68 @@ func updatetemplateInformation(dcrdClient *dcrrpcclient.Client) {
 	// Hacky way of populating the Vote Version bar graph
 	// Each element in each dataset needs counts for each interval
 	// For example:
-	// version 1: [100, 200, 300, 400]
-	stakeVersionIntervalResults := make([]intervalVersionCounts, 0)
-	stakeVersionLabels := make([]string, len(stakeVersionInfo.Intervals))
-	for i := len(stakeVersionInfo.Intervals) - 1; i >= 0; i-- {
-		interval := stakeVersionInfo.Intervals[i]
-		stakeVersionLabels[len(stakeVersionInfo.Intervals)-1-i] = fmt.Sprintf("%v - %v", interval.StartHeight, interval.EndHeight)
-		for _, stakeVersion := range interval.VoteVersions {
-			found := false
+	// version 1: [100, 200, 0, 400]
+	var stakeVersionIntervalResults []intervalVersionCounts
+	stakeVersionLabels := make([]string, numIntervals)
+	// Oldest to newest interval (charts are left to right)
+	for i := 0; i < numIntervals; i++ {
+		interval := &stakeVersionInfo.Intervals[numIntervals-1-i]
+		stakeVersionLabels[i] = fmt.Sprintf("%v - %v", interval.StartHeight, interval.EndHeight)
+	versionloop:
+		for _, versionCount := range interval.VoteVersions {
+			// Is this a vote version we've seen in a previous interval?
 			for k, result := range stakeVersionIntervalResults {
-				if result.Version == stakeVersion.Version {
-					stakeVersionIntervalResults[k].Count[len(stakeVersionInfo.Intervals)-1-i] = stakeVersion.Count
-					stakeVersionIntervalResults[k].Version = stakeVersion.Version
-					found = true
+				if result.Version == versionCount.Version {
+					stakeVersionIntervalResults[k].Count[i] = versionCount.Count
+					continue versionloop
 				}
 			}
-			if !found && stakeVersion.Count > minimumNeededVoteVersions {
-				stakeVersionIntervalResult := intervalVersionCounts{}
-				stakeVersionIntervalResult.Count = make([]uint32, len(stakeVersionInfo.Intervals))
-				stakeVersionIntervalResult.Count[len(stakeVersionInfo.Intervals)-1-i] = stakeVersion.Count
-				stakeVersionIntervalResult.Version = stakeVersion.Version
+			if versionCount.Count > minimumNeededVoteVersions {
+				stakeVersionIntervalResult := intervalVersionCounts{
+					Version: versionCount.Version,
+					Count:   make([]uint32, numIntervals),
+				}
+				stakeVersionIntervalResult.Count[i] = versionCount.Count
 				stakeVersionIntervalResults = append(stakeVersionIntervalResults, stakeVersionIntervalResult)
 			}
 		}
 	}
-	stakeVersionLabels[len(stakeVersionInfo.Intervals)-1] = "Current Interval"
+	stakeVersionLabels[numIntervals-1] = "Current Interval"
+	currentInterval := stakeVersionInfo.Intervals[0]
+
+	maxPossibleVotes := activeNetParams.StakeVersionInterval*int64(activeNetParams.TicketsPerBlock) -
+		int64(missedVotesStakeInterval)
+
 	templateInformation.StakeVersionIntervalResults = stakeVersionIntervalResults
-	templateInformation.StakeVersionWindowVoteTotal = activeNetParams.StakeVersionInterval*5 - int64(missedVotesStakeInterval)
+	templateInformation.StakeVersionWindowVoteTotal = maxPossibleVotes
 	templateInformation.StakeVersionIntervalLabels = stakeVersionLabels
 	templateInformation.StakeVersionCurrent = blockHeader.StakeVersion
 
-	mostPopularVersion := uint32(0)
-	mostPopularVersionCount := uint32(0)
-	for _, stakeVersion := range stakeVersionInfo.Intervals[0].VoteVersions {
-		if stakeVersion.Version != templateInformation.StakeVersionCurrent &&
+	var mostPopularVersion, mostPopularVersionCount uint32
+	for _, stakeVersion := range currentInterval.VoteVersions {
+		if stakeVersion.Version > blockHeader.StakeVersion &&
 			stakeVersion.Count > mostPopularVersionCount {
 			mostPopularVersion = stakeVersion.Version
 			mostPopularVersionCount = stakeVersion.Count
 		}
 	}
-	if mostPopularVersion <= templateInformation.StakeVersionCurrent {
+
+	templateInformation.StakeVersionMostPopularCount = mostPopularVersionCount
+	templateInformation.StakeVersionMostPopularPercentage = toFixed(float64(mostPopularVersionCount)/
+		float64(maxPossibleVotes)*100, 2)
+	templateInformation.StakeVersionMostPopular = mostPopularVersion
+	templateInformation.StakeVersionRequiredVotes = int32(maxPossibleVotes) *
+		activeNetParams.StakeMajorityMultiplier / activeNetParams.StakeMajorityDivisor
+	if int32(mostPopularVersionCount) > templateInformation.StakeVersionRequiredVotes {
 		templateInformation.StakeVersionSuccess = true
 	}
-	templateInformation.StakeVersionMostPopularCount = mostPopularVersionCount
-	templateInformation.StakeVersionMostPopularPercentage = toFixed(float64(mostPopularVersionCount)/float64(templateInformation.StakeVersionWindowVoteTotal)*100, 2)
-	templateInformation.StakeVersionMostPopular = mostPopularVersion
-	templateInformation.StakeVersionRequiredVotes = int32(templateInformation.StakeVersionWindowVoteTotal) * activeNetParams.StakeMajorityMultiplier / activeNetParams.StakeMajorityDivisor
 
-	blocksIntoInterval := stakeVersionInfo.Intervals[0].EndHeight - stakeVersionInfo.Intervals[0].StartHeight
-	templateInformation.StakeVersionVotesRemaining = (activeNetParams.StakeVersionInterval - blocksIntoInterval) * 5
+	blocksIntoInterval := currentInterval.EndHeight - currentInterval.StartHeight
+	templateInformation.StakeVersionVotesRemaining =
+		(activeNetParams.StakeVersionInterval - blocksIntoInterval) * int64(activeNetParams.TicketsPerBlock)
 
 	// Quorum/vote information
-	// NOTE: vote version will not be hard coded as it will change with time,
-	// and the web page will show multiple agendas at once. This is temporary.
-	voteVersion := uint32(4)
-	getVoteInfo, err := dcrdClient.GetVoteInfo(voteVersion)
+	getVoteInfo, err := dcrdClient.GetVoteInfo(mostPopularVersion)
 	if err != nil {
 		fmt.Println("Get vote info err", err)
 		templateInformation.Quorum = false
@@ -261,68 +277,49 @@ func updatetemplateInformation(dcrdClient *dcrrpcclient.Client) {
 
 	// There may be no agendas for this vote version
 	if len(getVoteInfo.Agendas) == 0 {
-		fmt.Printf("No agendas for vote version %d\n", voteVersion)
+		fmt.Printf("No agendas for vote version %d\n", mostPopularVersion)
 		return
 	}
 
-	// Set Quorum to true since we got a valid response back from GetVoteInfoResult
-	templateInformation.Quorum = true
-
-	// These fields can be refactored out of GetVoteInfoResults
-	templateInformation.QuorumExpirationDate = time.Unix(int64(getVoteInfo.Agendas[0].ExpireTime), int64(0)).Format(time.RFC850)
-	templateInformation.QuorumVotedPercentage = toFixed(getVoteInfo.Agendas[0].QuorumProgress*100, 2)
-	templateInformation.QuorumAbstainedPercentage = toFixed(getVoteInfo.Agendas[0].Choices[0].Progress*100, 2)
-	templateInformation.AgendaID = getVoteInfo.Agendas[0].Id
-	templateInformation.AgendaDescription = getVoteInfo.Agendas[0].Description
+	// Set Quorum to true since we got a valid response back from GetVoteInfoResult (?)
+	if getVoteInfo.TotalVotes >= getVoteInfo.Quorum {
+		templateInformation.Quorum = true
+	}
 
 	// Status LockedIn Circle3 Ring Indicates BlocksLeft until old versions gets denied
 	lockedinBlocksleft := float64(getVoteInfo.EndHeight) - float64(getVoteInfo.CurrentHeight)
 	lockedinWindowsize := float64(getVoteInfo.EndHeight) - float64(getVoteInfo.StartHeight)
 	lockedinPercentage := lockedinWindowsize / 100
-	templateInformation.AgendaLockedinPercentage = toFixed(lockedinBlocksleft/lockedinPercentage, 2)
 
-	// Recalculating Vote Percentages for Donut Chart
+	templateInformation.LockedinPercentage = toFixed(lockedinBlocksleft/lockedinPercentage, 2)
+	templateInformation.Agendas = make([]Agenda, 0, len(getVoteInfo.Agendas))
 
-	// XX instread of static linking there should be itteration trough the Choices array
-	templateInformation.AgendaChoice1Id = getVoteInfo.Agendas[0].Choices[0].Id
-	templateInformation.AgendaChoice1Description = getVoteInfo.Agendas[0].Choices[0].Description
-	templateInformation.AgendaChoice1Count = getVoteInfo.Agendas[0].Choices[0].Count
-	templateInformation.AgendaChoice1IsIgnore = getVoteInfo.Agendas[0].Choices[0].IsAbstain
-	templateInformation.AgendaChoice1Bits = getVoteInfo.Agendas[0].Choices[0].Bits
-	templateInformation.AgendaChoice1Progress = toFixed(getVoteInfo.Agendas[0].Choices[0].Progress*100, 2)
-	templateInformation.AgendaChoice2Id = getVoteInfo.Agendas[0].Choices[1].Id
-	templateInformation.AgendaChoice2Description = getVoteInfo.Agendas[0].Choices[1].Description
-	templateInformation.AgendaChoice2Count = getVoteInfo.Agendas[0].Choices[1].Count
-	templateInformation.AgendaChoice2IsIgnore = getVoteInfo.Agendas[0].Choices[1].IsAbstain
-	templateInformation.AgendaChoice2Bits = getVoteInfo.Agendas[0].Choices[1].Bits
-	templateInformation.AgendaChoice2Progress = toFixed(getVoteInfo.Agendas[0].Choices[1].Progress*100, 2)
-	templateInformation.AgendaChoice3Id = getVoteInfo.Agendas[0].Choices[2].Id
-	templateInformation.AgendaChoice3Description = getVoteInfo.Agendas[0].Choices[2].Description
-	templateInformation.AgendaChoice3Count = getVoteInfo.Agendas[0].Choices[2].Count
-	templateInformation.AgendaChoice3IsIgnore = getVoteInfo.Agendas[0].Choices[2].IsAbstain
-	templateInformation.AgendaChoice3Bits = getVoteInfo.Agendas[0].Choices[2].Bits
-	templateInformation.AgendaChoice3Progress = toFixed(getVoteInfo.Agendas[0].Choices[2].Progress*100, 2)
+	for i := range getVoteInfo.Agendas {
+		// templateInformation.VotingStarted = getVoteInfo.Agendas[0].Status == "started"
+		// templateInformation.VotingDefined = getVoteInfo.Agendas[0].Status == "defined"
+		// templateInformation.VotingLockedin = getVoteInfo.Agendas[0].Status == "lockedin"
+		// templateInformation.VotingFailed = getVoteInfo.Agendas[0].Status == "failed"
+		// templateInformation.VotingActive = getVoteInfo.Agendas[0].Status == "active"
+		// templateInformation.QuorumAchieved = getVoteInfo.Agendas[0].QuorumProgress == 1
 
-	templateInformation.VotingStarted = getVoteInfo.Agendas[0].Status == "started"
-	templateInformation.VotingDefined = getVoteInfo.Agendas[0].Status == "defined"
-	templateInformation.VotingLockedin = getVoteInfo.Agendas[0].Status == "lockedin"
-	templateInformation.VotingFailed = getVoteInfo.Agendas[0].Status == "failed"
-	templateInformation.VotingActive = getVoteInfo.Agendas[0].Status == "active"
-	templateInformation.QuorumAchieved = getVoteInfo.Agendas[0].QuorumProgress == 1
-
-	choiceIds := make([]string, len(getVoteInfo.Agendas[0].Choices))
-	choicePercentages := make([]float64, len(getVoteInfo.Agendas[0].Choices))
-	for i, choice := range getVoteInfo.Agendas[0].Choices {
-		if choice.IsAbstain {
-
-		} else {
-			choiceIds[i] = choice.Id
-			choicePercentages[i] = toFixed(choice.Progress*100, 2)
+		choiceIds := make([]string, len(getVoteInfo.Agendas[i].Choices))
+		choicePercentages := make([]float64, len(getVoteInfo.Agendas[i].Choices))
+		for i, choice := range getVoteInfo.Agendas[i].Choices {
+			if !choice.IsAbstain {
+				choiceIds[i] = choice.Id
+				choicePercentages[i] = toFixed(choice.Progress*100, 2)
+			}
 		}
-	}
-	templateInformation.ChoiceIds = choiceIds
-	templateInformation.ChoicePercentages = choicePercentages
 
+		templateInformation.Agendas = append(templateInformation.Agendas, Agenda{
+			Agenda:                    getVoteInfo.Agendas[i],
+			QuorumExpirationDate:      time.Unix(int64(getVoteInfo.Agendas[i].ExpireTime), int64(0)).Format(time.RFC850),
+			QuorumVotedPercentage:     toFixed(getVoteInfo.Agendas[i].QuorumProgress*100, 2),
+			QuorumAbstainedPercentage: toFixed(getVoteInfo.Agendas[i].Choices[0].Progress*100, 2),
+			ChoiceIDs:                 choiceIds,
+			ChoicePercentages:         choicePercentages,
+		})
+	}
 }
 
 // main wraps mainCore, which does all the work, because deferred functions do

--- a/public/views/start.html
+++ b/public/views/start.html
@@ -27,7 +27,7 @@
   <script src="js/modernizr.js" type="text/javascript"></script>
   <style>
   .progress-percent.pow {
-  width: {{.BlockVersionMostPopularPercentage}}%;
+  width: {{.BlockVersionNextPercentage}}%;
   {{if not .BlockVersionSuccess}}
   background-color:#fd714b;
   {{end}}
@@ -95,8 +95,10 @@ The second step of this process is the actual voting. The previous {{.StakeVersi
                 {{else}}
                 <span class="highlight-text orange">v{{.BlockVersionCurrent}}</span>
                 {{end}}
-                <br> Most Popular Version: <span class="highlight-text green">v{{.BlockVersionMostPopular}}</span>
-                <br> Most Popular: <span class="highlight-text">{{.BlockVersionMostPopularPercentage}}%</span>
+                <br> Next Version: <span class="highlight-text green">v{{.BlockVersionNext}}</span>
+                <br> Next: <span class="highlight-text">{{.BlockVersionNextPercentage}}%</span>
+                <!--<br> Most Popular Version: <span class="highlight-text green">v{{.BlockVersionMostPopular}}</span>
+                <br> Most Popular: <span class="highlight-text">{{.BlockVersionMostPopularPercentage}}%</span>-->
                 <br> Reject Threshold: <span class="highlight-text">{{.BlockVersionRejectThreshold}}%</span>
                 <br> Rolling Window: <span class="highlight-text">{{.BlockVersionWindowLength}} Blocks</span>
               </div>
@@ -107,7 +109,7 @@ The second step of this process is the actual voting. The previous {{.StakeVersi
                 <div class="pow progress-percent"></div>
               </div>
               <div class="pow-pos-upgrade progress-bar-threshold"></div>
-              <div class="heading progress-bar-pow-pos-percent">{{.BlockVersionMostPopularPercentage}}%</div>
+              <div class="heading progress-bar-pow-pos-percent">{{.BlockVersionNextPercentage}}%</div>
             </div>
           </div>
           <div class="chart pow w-clearfix">
@@ -120,8 +122,10 @@ The second step of this process is the actual voting. The previous {{.StakeVersi
                 {{else}}
                 <span class="highlight-text orange">v{{.BlockVersionCurrent}}</span>
                 {{end}}
-                <br> Most Popular Version: <span class="highlight-text green">v{{.BlockVersionMostPopular}}</span>
-                <br> Most Popular: <span class="highlight-text">{{.BlockVersionMostPopularPercentage}}%</span>
+                <br> Next Version: <span class="highlight-text green">v{{.BlockVersionNext}}</span>
+                <br> Next: <span class="highlight-text">{{.BlockVersionNextPercentage}}%</span>
+                <!--<br> Most Popular Version: <span class="highlight-text green">v{{.BlockVersionMostPopular}}</span>
+                <br> Most Popular: <span class="highlight-text">{{.BlockVersionMostPopularPercentage}}%</span>-->
                 <br> Reject Threshold: <span class="highlight-text">{{.BlockVersionRejectThreshold}}%</span>
                 <br> Rolling Window: <span class="highlight-text">{{.BlockVersionWindowLength}} Blocks</span>
               </div>

--- a/public/views/start.html
+++ b/public/views/start.html
@@ -217,43 +217,44 @@ The second step of this process is the actual voting. The previous {{.StakeVersi
       <div class="agendas w-clearfix width-1180">
   
 <!-- agenda loop start -->
-        {{if or .VotingActive .VotingLockedin .VotingFailed}}
+    {{range $i, $agenda := .Agendas}}
+        {{if or $agenda.IsActive $agenda.IsLockedIn $agenda.IsFailed }}
         <div class="agenda drop-shadow-n-element w-clearfix">
         {{end}}
-        {{if or .VotingDefined .VotingStarted}}
+        {{if or $agenda.IsDefined $agenda.IsStarted}}
         <div class="agenda drop-shadow-first-element w-clearfix">
         {{end}}
           <div class="agenda-section w-clearfix">
             <div class="agenda-indicator w-clearfix">
               <!-- labels -->
-              {{if .VotingDefined}}
+              {{if $agenda.IsDefined}}
               <div class="indicator upcoming">upcoming</div>
               {{end}}
-              {{if .VotingStarted}}
+              {{if $agenda.IsStarted}}
               <div class="in-progress indicator">in-progress</div>
               {{end}}
-              {{if .VotingActive}}
+              {{if $agenda.IsActive}}
               <div class="finished indicator">Finished</div>
               {{end}}
-              {{if .VotingFailed}}
+              {{if $agenda.IsFailed}}
               <div class="failed indicator">Failed</div>
               {{end}}
-              {{if .VotingLockedin}}
+              {{if $agenda.IsLockedIn}}
               <div class="finished indicator">Lockedin</div>
               {{end}}
 
               <!-- status icons -->
-              {{if .VotingLockedin}}
+              {{if $agenda.IsLockedIn}}
               <div class="indicator-icon lockin" data-tooltip-text="Lock-in phase, new rules not yet activated"></div>
               {{end}}
-              {{if .VotingActive}}
+              {{if $agenda.IsActive}}
                <div class="activated indicator-icon active" data-tooltip-text="Voting Succeeded, New Rules Activated"></div>
               {{end}}
 
               <!-- quorum indicator -->
-              {{if .VotingStarted}}
+              {{if $agenda.IsStarted}}
               <div class="quorum w-clearfix">Quorum: &nbsp;
-                {{if .QuorumAchieved}}
+                {{if eq $agenda.QuorumProgress 1.0}}
                 <span class="highlight-text green transparent quorum">Yes</span>
                 {{else}}
                 <span class="highlight-text orange transparent quorum">No</span>
@@ -264,31 +265,31 @@ The second step of this process is the actual voting. The previous {{.StakeVersi
 
             <!-- agenda details -->
             <div class="w-clearfix width-half">
-              <div class="agenda heading">{{.AgendaID}}</div>
+              <div class="agenda heading">{{$agenda.Id}}</div>
               <div class="agenda-cfg w-clearfix">
-                <div class="agenda-cfg-spec w-clearfix">Agenda ID: &nbsp;<span class="highlight-text cyan transparent">#{{.AgendaID}}</span>
+                <div class="agenda-cfg-spec w-clearfix">Agenda ID: &nbsp;<span class="highlight-text cyan transparent">#{{$agenda.Id}}</span>
                 </div>
-                <div class="agenda-cfg-spec w-clearfix">Voting Interval: &nbsp;<span class="highlight-text cyan transparent">{{.GetVoteInfoResult.StartHeight}}-{{.GetVoteInfoResult.EndHeight}}</span>
+                <div class="agenda-cfg-spec w-clearfix">Voting Interval: &nbsp;<span class="highlight-text cyan transparent">{{$.GetVoteInfoResult.StartHeight}}-{{$.GetVoteInfoResult.EndHeight}}</span>
                 </div>
                 <div class="agenda-cfg-spec w-clearfix">If anything missing: &nbsp;<span class="highlight-text cyan transparent">Add here</span>
                 </div>
               </div>
               <div class="agenda-paragraph">
-                <p>{{.AgendaDescription}}</p>
-                {{if and .StakeVersionSuccess .BlockVersionSuccess .VotingDefined}}
-                <p>Blocks left {{if .VotingStarted}}for{{else}}until{{end}} voting: {{minus64 .GetVoteInfoResult.EndHeight .GetVoteInfoResult.CurrentHeight}}</p>
+                <p>{{$agenda.Description}}</p>
+                {{if and $.StakeVersionSuccess $.BlockVersionSuccess $agenda.IsDefined}}
+                <p>Blocks left {{if $agenda.IsStarted}}for{{else}}until{{end}} voting: {{minus64 $.GetVoteInfoResult.EndHeight $.GetVoteInfoResult.CurrentHeight}}</p>
                 {{end}}
-                {{if .VotingStarted}}
-                  {{if .QuorumAchieved}}
-                    <p><strong>Success!</strong> We have reached the minimum Quorum of {{.QuorumThreshold}}% actively made votes.<br />
-                    There are <strong>{{minus64 .GetVoteInfoResult.EndHeight .GetVoteInfoResult.CurrentHeight}}</strong> blocks left in the vote.
+                {{if $agenda.IsStarted}}
+                  {{if eq $agenda.QuorumProgress 1.0}}
+                    <p><strong>Success!</strong> We have reached the minimum Quorum of {{$.QuorumThreshold}}% actively made votes.<br />
+                    There are <strong>{{minus64 $.GetVoteInfoResult.EndHeight $.GetVoteInfoResult.CurrentHeight}}</strong> blocks left in the vote.
                     </p>
                   {{else}}
-                    <p>We have yet not reached the minimum Quorum of {{.QuorumThreshold}}% actively made votes.
+                    <p>We have yet not reached the minimum Quorum of {{$.QuorumThreshold}}% actively made votes.
                     </p>
                   {{end}}
                 {{end}}
-                {{if .VotingActive}}
+                {{if $agenda.IsActive}}
                     <p>The new rules have been activated. Ensure you are running a recent enough software version that supports the new rules. Visit our <a href="https://forum.decred.org/forums/development-dispatches/" target="_blank">Forum</a> to get the latest Development Dispatches.
                     </p>
                 {{end}}
@@ -347,7 +348,7 @@ The second step of this process is the actual voting. The previous {{.StakeVersi
           </div>
 
           <!-- agenda voting results barchart -->
-          {{if .VotingStarted}}
+          {{if $agenda.IsStarted}}
           <div class="agenda-section progress-bar w-clearfix">
             <div class="progress-bar-agenda w-clearfix">
               <div class="progress-bar-competing-options-and-total-votes w-clearfix">
@@ -365,28 +366,29 @@ The second step of this process is the actual voting. The previous {{.StakeVersi
           {{end}}
 
           <!-- agenda toplabel -->
-          {{if and .StakeVersionSuccess .BlockVersionSuccess .VotingDefined}}
-          <div class="agenda-voting-begins">Starts in {{minus64 .GetVoteInfoResult.EndHeight .GetVoteInfoResult.CurrentHeight}} blocks</div>
+          {{if and $.StakeVersionSuccess $.BlockVersionSuccess $agenda.IsDefined}}
+          <div class="agenda-voting-begins">Starts in {{minus64 $.GetVoteInfoResult.EndHeight $.GetVoteInfoResult.CurrentHeight}} blocks</div>
           {{end}}
-          {{if .VotingStarted}}
-            {{if .QuorumAchieved}}
+          {{if $agenda.IsStarted}}
+            {{if eq $agenda.QuorumProgress 1.0}}
               <div class="agenda-voting-begins">Quorum achieved
               </div>
             {{else}}
-              <div class="agenda-voting-begins">Quorum Progress: {{.QuorumVotedPercentage }}%
+              <div class="agenda-voting-begins">Quorum Progress: {{$agenda.QuorumVotedPercentage }}%
               </div>
             {{end}} 
           {{end}}
-          {{if .VotingLockedin}}
+          {{if $agenda.IsLockedIn}}
             <div class="agenda-voting-begins">
-              Success - Please Upgrade your Software - <strong>{{minus64 .GetVoteInfoResult.EndHeight .GetVoteInfoResult.CurrentHeight}}</strong> blocks left
+              Success - Please Upgrade your Software - <strong>{{minus64 $.GetVoteInfoResult.EndHeight $.GetVoteInfoResult.CurrentHeight}}</strong> blocks left
             </div>
           {{end}}
-          {{if .VotingFailed}}
+          {{if $agenda.IsFailed}}
             <div class="agenda-voting-begins">Voting failed
             </div>
           {{end}}
         </div>
+      {{end}}
 <!-- agenda loop end -->
 
 

--- a/web.go
+++ b/web.go
@@ -40,6 +40,10 @@ type templateFields struct {
 	BlockVersionMostPopular int32
 	// BlockVersionMostPopularPercentage is the percentage of the most popular block version
 	BlockVersionMostPopularPercentage float64
+	// BlockVersionNext is teh next block version.
+	BlockVersionNext           int32
+	// BlockVersionNextPercentage is the share of the next block version in the current rolling window.
+	BlockVersionNextPercentage float64
 
 	// StakeVersion Information
 	//

--- a/web.go
+++ b/web.go
@@ -13,12 +13,34 @@ import (
 )
 
 type Agenda struct {
-	dcrjson.Agenda
+	dcrjson.Agenda            `storm:"inline"`
 	QuorumExpirationDate      string
 	QuorumVotedPercentage     float64
 	QuorumAbstainedPercentage float64
 	ChoiceIDs                 []string
 	ChoicePercentages         []float64
+	StartHeight               int64
+}
+
+// status: started, defined, lockedin, failed, active
+
+func (a *Agenda) IsActive() bool {
+	return a.Status == "active"
+}
+
+func (a *Agenda) IsStarted() bool {
+	return a.Status == "started"
+}
+
+func (a *Agenda) IsDefined() bool {
+	return a.Status == "defined"
+}
+func (a *Agenda) IsLockedIn() bool {
+	return a.Status == "lockedin"
+}
+
+func (a *Agenda) IsFailed() bool {
+	return a.Status == "failed"
 }
 
 // Overall data structure given to the template to render.
@@ -92,12 +114,6 @@ type templateFields struct {
 	Quorum bool
 	// QuorumThreshold is the percentage required for the RuleChange to become active.
 	QuorumThreshold float64
-	// QuorumVotedPercentage is the percentage of progress toward quorum XXX needs to be fixed.
-	QuorumVotedPercentage float64
-	// QuorumAbstainedPercentage is the abstain percentage.
-	QuorumAbstainedPercentage float64
-	// QuorumExpirationDate is the date in which the agenda is scheduled to expire.
-	QuorumExpirationDate string
 
 	LockedinPercentage float64
 

--- a/web.go
+++ b/web.go
@@ -12,6 +12,8 @@ import (
 	"github.com/decred/dcrd/dcrjson"
 )
 
+// Agenda embeds the Agenda returned by getvoteinfo with several fields to
+// facilitate the html template programming.
 type Agenda struct {
 	dcrjson.Agenda            `storm:"inline"`
 	QuorumExpirationDate      string
@@ -22,23 +24,29 @@ type Agenda struct {
 	StartHeight               int64
 }
 
-// status: started, defined, lockedin, failed, active
+// Agenda status may be: started, defined, lockedin, failed, active
 
+// IsActive indicates if the agenda is active
 func (a *Agenda) IsActive() bool {
 	return a.Status == "active"
 }
 
+// IsStarted indicates if the agenda is started
 func (a *Agenda) IsStarted() bool {
 	return a.Status == "started"
 }
 
+// IsDefined indicates if the agenda is defined
 func (a *Agenda) IsDefined() bool {
 	return a.Status == "defined"
 }
+
+// IsLockedIn indicates if the agenda is lockedin
 func (a *Agenda) IsLockedIn() bool {
 	return a.Status == "lockedin"
 }
 
+// IsFailed indicates if the agenda is failed
 func (a *Agenda) IsFailed() bool {
 	return a.Status == "failed"
 }
@@ -114,7 +122,7 @@ type templateFields struct {
 	Quorum bool
 	// QuorumThreshold is the percentage required for the RuleChange to become active.
 	QuorumThreshold float64
-
+	// LockedinPercentage is the percent of the voing window remaining
 	LockedinPercentage float64
 
 	// Agendas contains all the agendas and their statuses
@@ -122,9 +130,6 @@ type templateFields struct {
 
 	// GetVoteInfoResult has all the raw data returned from getvoteinfo json-rpc command.
 	GetVoteInfoResult *dcrjson.GetVoteInfoResult
-	// Choice Ids and percentages that have been scrubbed for graphing.
-	ChoiceIds         []string
-	ChoicePercentages []float64
 }
 
 var funcMap = template.FuncMap{

--- a/web.go
+++ b/web.go
@@ -12,6 +12,15 @@ import (
 	"github.com/decred/dcrd/dcrjson"
 )
 
+type Agenda struct {
+	dcrjson.Agenda
+	QuorumExpirationDate      string
+	QuorumVotedPercentage     float64
+	QuorumAbstainedPercentage float64
+	ChoiceIDs                 []string
+	ChoicePercentages         []float64
+}
+
 // Overall data structure given to the template to render.
 type templateFields struct {
 
@@ -89,36 +98,12 @@ type templateFields struct {
 	QuorumAbstainedPercentage float64
 	// QuorumExpirationDate is the date in which the agenda is scheduled to expire.
 	QuorumExpirationDate string
-	// All of these are already contained in GetVoteInfoResult, so we need to refactor the html
-	// to properly use these.
-	AgendaLockedinPercentage float64
-	AgendaID                 string
-	AgendaDescription        string
-	AgendaChoice1Id          string
-	AgendaChoice1Description string
-	AgendaChoice1Count       uint32
-	AgendaChoice1IsIgnore    bool
-	AgendaChoice1Bits        uint16
-	AgendaChoice1Progress    float64
-	AgendaChoice2Id          string
-	AgendaChoice2Description string
-	AgendaChoice2Count       uint32
-	AgendaChoice2IsIgnore    bool
-	AgendaChoice2Bits        uint16
-	AgendaChoice2Progress    float64
-	AgendaChoice3Id          string
-	AgendaChoice3Description string
-	AgendaChoice3Count       uint32
-	AgendaChoice3IsIgnore    bool
-	AgendaChoice3Bits        uint16
-	AgendaChoice3Progress    float64
-	// These are bools to determine what state a given agenda is at.  These need to be refactored with stuff above.
-	VotingStarted  bool
-	VotingDefined  bool
-	VotingLockedin bool
-	VotingFailed   bool
-	VotingActive   bool
-	QuorumAchieved bool
+
+	LockedinPercentage float64
+
+	// Agendas contains all the agendas and their statuses
+	Agendas []Agenda
+
 	// GetVoteInfoResult has all the raw data returned from getvoteinfo json-rpc command.
 	GetVoteInfoResult *dcrjson.GetVoteInfoResult
 	// Choice Ids and percentages that have been scrubbed for graphing.

--- a/web.go
+++ b/web.go
@@ -41,7 +41,7 @@ type templateFields struct {
 	// BlockVersionMostPopularPercentage is the percentage of the most popular block version
 	BlockVersionMostPopularPercentage float64
 	// BlockVersionNext is teh next block version.
-	BlockVersionNext           int32
+	BlockVersionNext int32
 	// BlockVersionNextPercentage is the share of the next block version in the current rolling window.
 	BlockVersionNextPercentage float64
 


### PR DESCRIPTION
This contains:
1. Phase 1 (upgrade) info refactoring.
2. Implementation of multi-agenda, which includes a new `Agenda` type in web.go that embeds `dcrjson.Agenda` with other helpful fields and methods for easy use by the html template.

The new bits look like this:

![image](https://cloud.githubusercontent.com/assets/9373513/25575237/523a5c96-2e0a-11e7-856c-5e8236ba13b5.png)

**This is still a WIP, but please review ASAP.**  To start, it's still not clear to me how "most popular" should be understood in phase 1, and how this relates to current and next, for both block and stake versions.