### PR TITLE
Get DCP number from agenda description

### DIFF
--- a/web.go
+++ b/web.go
@@ -56,7 +56,7 @@ func (a *Agenda) IsFailed() bool {
 
 // IsDCP indicates if agenda has a dcp paper
 func (a *Agenda) IsDcp() bool {
-	var dcpMustHave = regexp.MustCompile(`\DCP(\d{4})`)
+	var dcpMustHave = regexp.MustCompile(`\DCP\-?(\d{4})`)
 	return dcpMustHave.MatchString(a.Description)
 }
 

--- a/web.go
+++ b/web.go
@@ -54,9 +54,9 @@ func (a *Agenda) IsFailed() bool {
 	return a.Status == "failed"
 }
 
-// IsDCP indicates if agenda has a dcp paper
-func (a *Agenda) IsDcp() bool {
-	var dcpMustHave = regexp.MustCompile(`\DCP\-?(\d{4})`)
+// IsDCP indicates if agenda has a DCP paper
+func (a *Agenda) IsDCP() bool {
+	var dcpMustHave = regexp.MustCompile(`(?i)DCP\-?(\d{4,6})`)
 	return dcpMustHave.MatchString(a.Description)
 }
 

--- a/web.go
+++ b/web.go
@@ -60,6 +60,18 @@ func (a *Agenda) IsDCP() bool {
 	return dcpMustHave.MatchString(a.Description)
 }
 
+// DCPNumber gets the DCP number as a string with any leading zeros
+func (a *Agenda) DCPNumber() string {
+	re := regexp.MustCompile(`(?i)DCP\-?(\d{4,6})`)
+	if re.MatchString(a.Description) {
+		matches := re.FindStringSubmatch(a.Description)
+		if len(matches) > 1 {
+			return matches[1]
+		}
+	}
+	return ""
+}
+
 // Overall data structure given to the template to render.
 type templateFields struct {
 

--- a/web.go
+++ b/web.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"regexp"
 
 	"github.com/decred/dcrd/dcrjson"
 )
@@ -51,6 +52,12 @@ func (a *Agenda) IsLockedIn() bool {
 // IsFailed indicates if the agenda is failed
 func (a *Agenda) IsFailed() bool {
 	return a.Status == "failed"
+}
+
+// IsDCP indicates if agenda has a dcp paper
+func (a *Agenda) IsDcp() bool {
+	var dcpMustHave = regexp.MustCompile(`\DCP(\d{4})`)
+	return dcpMustHave.MatchString(a.Description)
 }
 
 // Overall data structure given to the template to render.

--- a/web_test.go
+++ b/web_test.go
@@ -25,3 +25,25 @@ func TestIsDCP(t *testing.T) {
 		}
 	}
 }
+
+func TestDCPNumber(t *testing.T) {
+	strTests := []struct {
+		s string
+		r string
+	}{
+		{"DCP0001", "0001"},
+		{"CP0001", ""},
+		{"dcp0001", "0001"},
+		{"DCP-0001", "0001"},
+		{"DTP0001", ""},
+	}
+
+	a := Agenda{}
+
+	for _, ts := range strTests {
+		a.Description = ts.s
+		if ts.r != a.DCPNumber() {
+			t.Errorf("%s should have been %v", ts.s, ts.r)
+		}
+	}
+}

--- a/web_test.go
+++ b/web_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestIsDCP(t *testing.T) {
+	strTests := []struct {
+		s string
+		r bool
+	}{
+		{"DCP0001", true},
+		{"CP0001", false},
+		{"dcp0001", true},
+		{"DCP-0001", true},
+		{"DTP0001", false},
+	}
+
+	a := Agenda{}
+
+	for _, ts := range strTests {
+		a.Description = ts.s
+		if ts.r != a.IsDCP() {
+			t.Errorf("%s should have been %v", ts.s, ts.r)
+		}
+	}
+}

--- a/web_test.go
+++ b/web_test.go
@@ -10,7 +10,8 @@ func TestIsDCP(t *testing.T) {
 		r bool
 	}{
 		{"DCP0001", true},
-		{"CP0001", false},
+		{" CP0001", false},
+		{"XCP0001", false},
 		{"dcp0001", true},
 		{"DCP-0001", true},
 		{"DTP0001", false},


### PR DESCRIPTION
This is so it may be used to generate a link to the DCP on the web page.