### PR TITLE
Phase labels

### DIFF
--- a/main.go
+++ b/main.go
@@ -299,6 +299,14 @@ func updatetemplateInformation(dcrdClient *dcrrpcclient.Client, db *agendadb.Age
 	}
 	templateInformation.GetVoteInfoResult = getVoteInfo
 
+	// Check if Phase Upgrading or Voting
+	if templateInformation.StakeVersionSuccess && templateInformation.BlockVersionSuccess {
+		templateInformation.IsUpgrading = false
+	}else{
+		templateInformation.IsUpgrading = true
+	}
+	
+
 	// There may be no agendas for this vote version
 	if len(getVoteInfo.Agendas) == 0 {
 		fmt.Printf("No agendas for vote version %d\n", mostPopularVersion)

--- a/main.go
+++ b/main.go
@@ -302,10 +302,9 @@ func updatetemplateInformation(dcrdClient *dcrrpcclient.Client, db *agendadb.Age
 	// Check if Phase Upgrading or Voting
 	if templateInformation.StakeVersionSuccess && templateInformation.BlockVersionSuccess {
 		templateInformation.IsUpgrading = false
-	}else{
+	} else {
 		templateInformation.IsUpgrading = true
 	}
-	
 
 	// There may be no agendas for this vote version
 	if len(getVoteInfo.Agendas) == 0 {

--- a/public/css/decred-hardforkwebsite.css
+++ b/public/css/decred-hardforkwebsite.css
@@ -1388,7 +1388,7 @@ body {
 }
 
 .voting-overview {
-  height: 320px;
+  height: 400px;
   background-color: #596d81;
 }
 
@@ -1448,8 +1448,8 @@ body {
 }
 
 .width-590.voting-overview {
-  padding-top: 30px;
-  padding-bottom: 45px;
+  padding-top: 40px;
+  padding-bottom: 60px;
   padding-left: 50px;
   float: right;
 }
@@ -1457,6 +1457,7 @@ body {
 .width-590.voting-overview-graph {
   height: 320px;
   float: left;
+  margin-top: 30px;
   background-image: url('../images/infographic.svg');
   background-position: 50% 50%;
   background-size: contain;
@@ -1801,6 +1802,10 @@ body {
   float: left;
   font-size: 14px;
   line-height: 16px;
+  max-width: 440px;
+}
+.highlightoverview {
+  color: #18173F;
 }
 
 .chart-toggle-side {

--- a/public/views/start.html
+++ b/public/views/start.html
@@ -65,21 +65,21 @@
         {{else}}
 <!-- Phase 2 Voting -->
         <a class="header-link w-button" href="#"> | &nbsp;Current phase: Voting
-          {{range $i, $agenda := .Agendas}}
+          {{range $i, $agenda := .Agendas}}         
               {{if $agenda.IsDefined}}
-              <div class="indicator upcoming">{{$agenda.Id}}</div>
+              <div class="indicator upcoming">{{$agenda.Id}} Upcoming</div>
               {{end}}
               {{if $agenda.IsStarted}}
               <div class="in-progress indicator">{{$agenda.Id}} {{$agenda.QuorumVotedPercentage }}%</div>
               {{end}}
               {{if $agenda.IsActive}}
-              <div class="finished indicator">{{$agenda.Id}}</div>
+              <div class="finished indicator">{{$agenda.Id}} Success</div>
               {{end}}
               {{if $agenda.IsFailed}}
-              <div class="failed indicator">{{$agenda.Id}}</div>
+              <div class="failed indicator">{{$agenda.Id}} Failed</div>
               {{end}}
               {{if $agenda.IsLockedIn}}
-              <div class="finished indicator">{{$agenda.Id}}</div>
+              <div class="finished indicator">{{$agenda.Id}} LockedIn</div>
               {{end}}
           {{end}}
         </a>
@@ -97,7 +97,7 @@
 There is a two-phase process for voting to implement consensus changes that would create a hard fork.
             </p>
             <p>
-The first is meeting the upgrade threshold on the network. A majority of PoS/PoW nodes on the network must upgrade before voting can begin. 
+<span class="highlightoverview">The first Phase</span> is meeting the upgrade threshold on the network. A majority of PoS/PoW nodes on the network must upgrade before voting can begin. 
 This is measured in the following ways:
             </p>
             <p>
@@ -105,7 +105,7 @@ This is measured in the following ways:
 - For PoS, {{.StakeVersionThreshold}}% of the votes cast within a static {{.StakeVersionWindowLength}} block interval must have the latest vote version.
             </p>
             <p>
-The second phase is the voting itself. Voting takes place within a static {{.RuleChangeActivationInterval}} block interval. If 75% of votes mined within that interval signal a ‘yes’ vote to the proposals, the changes are implemented. Implementation happens after one additional block interval to allow any remaining nodes to update prior to the fork.
+<span class="highlightoverview">The second phase</span> is the voting itself. Voting takes place within a static {{.RuleChangeActivationInterval}} block interval. If 75% of votes mined within that interval signal a ‘yes’ vote to the proposals, the changes are implemented. Implementation happens after one additional block interval to allow any remaining nodes to update prior to the fork.
             </p>
         </div>
       </div>

--- a/public/views/start.html
+++ b/public/views/start.html
@@ -64,8 +64,8 @@
         </a>
         {{else}}
 <!-- Phase 2 Voting -->
-          {{range $i, $agenda := .Agendas}}
-              <a class="header-link w-button" href="#"> | &nbsp;Current phase: Voting        
+          <a class="header-link w-button" href="#"> | &nbsp;Current phase: Voting
+          {{range $i, $agenda := .Agendas}}        
               {{if $agenda.IsDefined}}
               <div class="indicator upcoming">{{$agenda.Id}} Upcoming</div>
               {{end}}
@@ -81,8 +81,8 @@
               {{if $agenda.IsLockedIn}}
               <div class="finished indicator">{{$agenda.Id}} LockedIn</div>
               {{end}}
-              </a>
           {{end}}
+          </a>
         {{end}}
         <a class="header-link w-button" href="{{.BlockExplorerLink}}">Block #{{.BlockHeight}}</a>
       </div>

--- a/public/views/start.html
+++ b/public/views/start.html
@@ -224,7 +224,7 @@ This is measured in the following ways:
             </div>
             <div class="progress-bar-pow-pos-upgrade">
               <div class="progress-indicator w-clearfix">
-                <div class="pow pos progress-percent"></div>
+                <div class="pos progress-percent"></div>
               </div>
               <div class="pow-pos-upgrade progress-bar-threshold" style="left: {{.StakeVersionThreshold}}%"></div>
               <div class="heading progress-bar-pow-pos-percent">{{.StakeVersionMostPopularPercentage}}%</div>

--- a/public/views/start.html
+++ b/public/views/start.html
@@ -61,9 +61,28 @@
         <a class="header-link w-button" href="#"> | &nbsp;Current phase: Upgrading 
           {{if .StakeVersionSuccess}}<div class="finished indicator transition">PoS</div>{{else}}<div class="in-progress indicator transition">PoS {{.StakeVersionMostPopularPercentage}}</div>{{end}}
           {{if .BlockVersionSuccess}}<div class="finished indicator transition">PoW</div>{{else}}<div class="in-progress indicator transition">PoW {{.BlockVersionNextPercentage}}%</div>{{end}}
+        </a>
         {{else}}
 <!-- Phase 2 Voting -->
-
+        <a class="header-link w-button" href="#"> | &nbsp;Current phase: Voting
+          {{range $i, $agenda := .Agendas}}
+              {{if $agenda.IsDefined}}
+              <div class="indicator upcoming">{{$agenda.Id}}</div>
+              {{end}}
+              {{if $agenda.IsStarted}}
+              <div class="in-progress indicator">{{$agenda.Id}} {{$agenda.QuorumVotedPercentage }}%</div>
+              {{end}}
+              {{if $agenda.IsActive}}
+              <div class="finished indicator">{{$agenda.Id}}</div>
+              {{end}}
+              {{if $agenda.IsFailed}}
+              <div class="failed indicator">{{$agenda.Id}}</div>
+              {{end}}
+              {{if $agenda.IsLockedIn}}
+              <div class="finished indicator">{{$agenda.Id}}</div>
+              {{end}}
+          {{end}}
+        </a>
         {{end}}
         <a class="header-link w-button" href="{{.BlockExplorerLink}}">Block #{{.BlockHeight}}</a>
       </div>

--- a/public/views/start.html
+++ b/public/views/start.html
@@ -56,12 +56,14 @@
         {{if eq .Network "testnet"}}
         <a class="header-link w-button" href="faucet.decred.org"> | &nbsp;Testnet Faucet</a>
         {{end}}
-        {{if not .BlockVersionSuccess}}
-        <a class="header-link w-button" href="#"> | &nbsp;Current phase: Upgrading v{{.BlockVersionCurrent}} -> v{{.BlockVersionNext}} ({{.BlockVersionNextPercentage}}% PoW, {{.StakeVersionMostPopularPercentage}}% PoS)</a>
+        {{if .IsUpgrading}}
+<!-- Phase 1 Upgrading -->
+        <a class="header-link w-button" href="#"> | &nbsp;Current phase: Upgrading 
+          {{if .StakeVersionSuccess}}<div class="finished indicator transition">PoS</div>{{else}}<div class="in-progress indicator transition">PoS {{.StakeVersionMostPopularPercentage}}</div>{{end}}
+          {{if .BlockVersionSuccess}}<div class="finished indicator transition">PoW</div>{{else}}<div class="in-progress indicator transition">PoW {{.BlockVersionNextPercentage}}%</div>{{end}}
         {{else}}
-        {{if not .StakeVersionSuccess}}
-        <a class="header-link w-button" href="#"> | &nbsp;Current phase: Upgrading v{{.StakeVersionCurrent}} -> v{{.StakeVersionMostPopular}} ({{.BlockVersionNextPercentage}}% PoW, {{.StakeVersionMostPopularPercentage}}% PoS)</a>
-        {{end}}
+<!-- Phase 2 Voting -->
+
         {{end}}
         <a class="header-link w-button" href="{{.BlockExplorerLink}}">Block #{{.BlockHeight}}</a>
       </div>

--- a/public/views/start.html
+++ b/public/views/start.html
@@ -64,8 +64,8 @@
         </a>
         {{else}}
 <!-- Phase 2 Voting -->
-        <a class="header-link w-button" href="#"> | &nbsp;Current phase: Voting
-          {{range $i, $agenda := .Agendas}}         
+          {{range $i, $agenda := .Agendas}}
+              <a class="header-link w-button" href="#"> | &nbsp;Current phase: Voting        
               {{if $agenda.IsDefined}}
               <div class="indicator upcoming">{{$agenda.Id}} Upcoming</div>
               {{end}}
@@ -81,8 +81,8 @@
               {{if $agenda.IsLockedIn}}
               <div class="finished indicator">{{$agenda.Id}} LockedIn</div>
               {{end}}
+              </a>
           {{end}}
-        </a>
         {{end}}
         <a class="header-link w-button" href="{{.BlockExplorerLink}}">Block #{{.BlockHeight}}</a>
       </div>

--- a/tplhardforkv1/src/css/decred-hardforkwebsite.css
+++ b/tplhardforkv1/src/css/decred-hardforkwebsite.css
@@ -1388,7 +1388,7 @@ body {
 }
 
 .voting-overview {
-  height: 320px;
+  height: 400px;
   background-color: #596d81;
 }
 
@@ -1448,8 +1448,8 @@ body {
 }
 
 .width-590.voting-overview {
-  padding-top: 30px;
-  padding-bottom: 45px;
+  padding-top: 40px;
+  padding-bottom: 60px;
   padding-left: 50px;
   float: right;
 }
@@ -1457,6 +1457,7 @@ body {
 .width-590.voting-overview-graph {
   height: 320px;
   float: left;
+  margin-top: 30px;
   background-image: url('../images/infographic.svg');
   background-position: 50% 50%;
   background-size: contain;
@@ -1801,6 +1802,10 @@ body {
   float: left;
   font-size: 14px;
   line-height: 16px;
+  max-width: 440px;
+}
+.highlightoverview {
+  color: #18173F;
 }
 
 .chart-toggle-side {

--- a/web.go
+++ b/web.go
@@ -137,6 +137,8 @@ type templateFields struct {
 	RuleChangeActivationInterval int64
 	// Agendas contains all the agendas and their statuses
 	Agendas []Agenda
+	// Phase Upgrading or Voting
+	IsUpgrading bool
 
 	// GetVoteInfoResult has all the raw data returned from getvoteinfo json-rpc command.
 	GetVoteInfoResult *dcrjson.GetVoteInfoResult


### PR DESCRIPTION
As suggested by Linnutee the Top Navbar should get a cleaner Labeling to see the current active Phase and the current status.

Overall we have two Phases - 1. Upgrading, 2. Voting

<img width="1128" alt="screen shot 2017-05-06 at 22 27 46" src="https://cloud.githubusercontent.com/assets/25404928/25777220/2642663e-32d7-11e7-9d80-c652a16de627.png">
<img width="428" alt="screen shot 2017-05-06 at 22 28 35" src="https://cloud.githubusercontent.com/assets/25404928/25777221/2a3a8bb8-32d7-11e7-940a-ca1c65ffe058.png">
<img src="https://cloud.githubusercontent.com/assets/25404928/25777603/272d9770-32e2-11e7-847e-bffb179a48bc.png">



This PR covers those Labels in the Top Navbar with the css Deffinitions that we currently have. Therefore another TemplateVariable used to trigger the current Phase was introduced ( IsUpgrading true/false )

The only thing missing in the current switches is the Phase in the Screenshot saying: "Waiting for Voting to begin" as it interferes with the agenda-loop and multiple agendas.

Visual Fixes for Voting Overview Box CSS spacing added.

Result of this PR currently looks like this:
![auswahl_144](https://cloud.githubusercontent.com/assets/25404928/25777696/36808a22-32e5-11e7-92fa-b3e58ae8ede4.png)

![auswahl_145](https://cloud.githubusercontent.com/assets/25404928/25780258/e7fe11ea-3324-11e7-858b-d2b494867e98.png)
