### PR TITLE
fix margin of agenda items in wide screen mode

### DIFF
--- a/tplhardforkv1/src/css/decred-hardforkwebsite.css
+++ b/tplhardforkv1/src/css/decred-hardforkwebsite.css
@@ -1476,6 +1476,7 @@ body {
 }
 
 .agenda.drop-shadow-first-element {
+  margin-top: 20px;
   box-shadow: 0 4px 10px 0 rgba(0, 0, 0, .2);
 }
 
@@ -2634,9 +2635,6 @@ body {
     padding-right: 50px;
     padding-bottom: 30px;
     padding-left: 50px;
-  }
-  .agenda.drop-shadow-first-element {
-    margin-top: 20px;
   }
   .chart-toggle-side {
     display: none;


### PR DESCRIPTION
the agenda spacing looks bad in wide screen currently, this simply applies the same spacing used in the other screen widths