### PR TITLE
Fix unclickable links on mobile.

### DIFF
--- a/public/css/decred-hardforkwebsite.css
+++ b/public/css/decred-hardforkwebsite.css
@@ -1289,7 +1289,6 @@ body {
 }
 
 .width-1180 {
-  position: relative;
   display: block;
   width: 1180px;
   margin-right: auto;


### PR DESCRIPTION
The &lt;a> was being covered by a parent &lt;div>. This happened because the &lt;div> was being given "position: relative" which cause it to be allocated a z-index, thus causing it to be rendered on top. The appearance of the page is not altered by removing the "position: relative".

Closes #149 