### PR TITLE
Format time remaining for upgrade.

### DIFF
--- a/main.go
+++ b/main.go
@@ -577,11 +577,11 @@ func toFixed(num float64, precision int) float64 {
 
 // fmtDuration will convert a Duration into a human readable string formatted "0d 0h 0m".
 func fmtDuration(dur time.Duration) string {
-    dur = dur.Round(time.Minute)
-    days := dur / (time.Hour * 24)
-    dur -= days * (time.Hour * 24)
-    hours := dur / time.Hour
-    dur -= hours * time.Hour
-    mins := dur / time.Minute
-    return fmt.Sprintf("%dd %dh %dm", days, hours, mins)
+	dur = dur.Round(time.Minute)
+	days := dur / (time.Hour * 24)
+	dur -= days * (time.Hour * 24)
+	hours := dur / time.Hour
+	dur -= hours * time.Hour
+	mins := dur / time.Minute
+	return fmt.Sprintf("%dd %dh %dm", days, hours, mins)
 }

--- a/main.go
+++ b/main.go
@@ -225,7 +225,7 @@ func updatetemplateInformation(dcrdClient *rpcclient.Client, db *agendadb.Agenda
 	}
 	blocksRemainingStakeInterval := stakeVersionIntervalEndHeight - int64(height)
 	timeLeftDuration := activeNetParams.TargetTimePerBlock * time.Duration(blocksRemainingStakeInterval)
-	templateInformation.StakeVersionTimeRemaining = fmt.Sprintf("%s remaining", timeLeftDuration.String())
+	templateInformation.StakeVersionTimeRemaining = fmt.Sprintf("%s remaining", fmtDuration(timeLeftDuration))
 	stakeVersionLabels[numIntervals-1] = "Current Interval"
 	currentInterval := stakeVersionInfo.Intervals[0]
 
@@ -573,4 +573,15 @@ func round(num float64) int {
 func toFixed(num float64, precision int) float64 {
 	output := math.Pow(10, float64(precision))
 	return float64(round(num*output)) / output
+}
+
+// fmtDuration will convert a Duration into a human readable string formatted "0d 0h 0m".
+func fmtDuration(dur time.Duration) string {
+    dur = dur.Round(time.Minute)
+    days := dur / (time.Hour * 24)
+    dur -= days * (time.Hour * 24)
+    hours := dur / time.Hour
+    dur -= hours * time.Hour
+    mins := dur / time.Minute
+    return fmt.Sprintf("%dd %dh %dm", days, hours, mins)
 }


### PR DESCRIPTION
This replaces the use of the formatting provided by the golang Duration package with custom
logic. The affect is to change format "0h0m0s" with "0d 0h 0m".

Motivation:

- Seconds is not very useful in this context
- The old format did not break down large numbers of hours into days. With the new format "169h10m0s" becomes "7d 1h 10m"
- Lack of spacing makes the old format hard to read