### PR TITLE
Extract hard-coded strings from template.

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"fmt"
+	"html/template"
 	"io/ioutil"
 	"log"
 	"math"
@@ -55,6 +56,18 @@ var (
 	// templateInformation is the template holding the active network
 	// parameters.
 	templateInformation *templateFields
+
+	friendlyAgendaLabels = map[string]string{
+		"sdiffalgorithm": "Change PoS Staking Algorithm",
+		"lnsupport":      "Start Lightning Network Support",
+		"lnfeatures":     "Enable Lightning Network Features",
+		"fixlnseqlocks":  "Update Sequence Lock Rules"}
+
+	longAgendaDescriptions = map[string]template.HTML{
+		"sdiffalgorithm": template.HTML("Specifies a proposed replacement algorithm for determining the stake difficulty (commonly called the ticket price). This proposal resolves all issues with a new algorithm that adheres to the referenced ideals."),
+		"lnsupport":      template.HTML("The <a href='https://lightning.network/' target='_blank' rel='noopener noreferrer'>Lightning Network</a> is the most directly useful application of smart contracts to date since it allows for off-chain transactions that optionally settle on-chain. This infrastructure has clear benefits for both scaling and privacy. Decred is optimally positioned for this integration."),
+		"lnfeatures":     template.HTML("The <a href='https://lightning.network/' target='_blank' rel='noopener noreferrer'>Lightning Network</a> is the most directly useful application of smart contracts to date since it allows for off-chain transactions that optionally settle on-chain. This infrastructure has clear benefits for both scaling and privacy. Decred is optimally positioned for this integration."),
+		"fixlnseqlocks":  template.HTML("In order to fully support the <a href='https://lightning.network/' target='_blank' rel='Noopener noreferrer'>Lightning Network</a>, the current sequence lock consensus rules need to be modified.")}
 )
 
 // updatetemplateInformation is called on startup and upon every block connected notification received.
@@ -68,6 +81,9 @@ func updatetemplateInformation(dcrdClient *rpcclient.Client) {
 	templateInformation.BlockHeight = height
 	templateInformation.BlockExplorerLink = fmt.Sprintf("https://%s.dcrdata.org/block/%v",
 		activeNetParams.Name, hash)
+
+	templateInformation.FriendlyAgendaLabels = friendlyAgendaLabels
+	templateInformation.LongAgendaDescriptions = longAgendaDescriptions
 
 	// Request GetStakeVersions to receive information about past block versions.
 	//

--- a/public/views/start.html
+++ b/public/views/start.html
@@ -319,8 +319,7 @@
             <!-- agenda details -->
             <div class="w-clearfix width-half">
               <div class="agenda heading">
-                {{if eq $agenda.ID "sdiffalgorithm"}}Change PoS Staking Algorithm{{end}}
-                {{if eq $agenda.ID "lnsupport"}}Start Lightning Network Support{{end}}
+                {{index $.FriendlyAgendaLabels $agenda.ID}}
               </div>
               <div class="agenda-cfg w-clearfix">
                 <div class="agenda-cfg-spec w-clearfix">Agenda ID: &nbsp;<span class="highlight-text cyan transparent">#{{$agenda.ID}}</span>
@@ -337,18 +336,7 @@
               </div>
               <div class="agenda-paragraph">
                 <p style="font-weight: bold;">{{$agenda.DescriptionWithDCPURL}}</p>
-                {{if eq $agenda.ID "sdiffalgorithm"}}
-                <p>Specifies a proposed replacement algorithm for determining the stake difficulty (commonly called the ticket price). This proposal resolves all issues with a new algorithm that adheres to the referenced ideals.</p>
-                {{end}}
-                {{if eq $agenda.ID "lnsupport"}}
-                <p>The <a href="https://lightning.network/" target="_blank" rel="noopener noreferrer">Lightning Network</a> is the most directly useful application of smart contracts to date since it allows for off-chain transactions that optionally settle on-chain. This infrastructure has clear benefits for both scaling and privacy. Decred is optimally positioned for this integration.</p>
-                {{end}}
-                {{if eq $agenda.ID "lnfeatures"}}
-                <p>The <a href="https://lightning.network/" target="_blank" rel="noopener noreferrer">Lightning Network</a> is the most directly useful application of smart contracts to date since it allows for off-chain transactions that optionally settle on-chain. This infrastructure has clear benefits for both scaling and privacy. Decred is optimally positioned for this integration.</p>
-                {{end}}
-                {{if eq $agenda.ID "fixlnseqlocks"}}
-                <p>In order to fully support the <a href="https://lightning.network/" target="_blank" rel="noopener noreferrer">Lightning Network</a>, the current sequence lock consensus rules need to be modified.</p>
-                 {{end}}
+                <p>{{index $.LongAgendaDescriptions $agenda.ID}}</p>
               </div>
             </div>
 

--- a/web.go
+++ b/web.go
@@ -160,6 +160,10 @@ type templateFields struct {
 	GetVoteInfoResult *dcrjson.GetVoteInfoResult
 	// TimeLeftString shows the approximate time left until activation
 	TimeLeftString string
+	// Human friendly readable labels for each agenda
+	FriendlyAgendaLabels map[string]string
+	// Human friendly readable descriptions for each agenda
+	LongAgendaDescriptions map[string]template.HTML
 }
 
 var funcMap = template.FuncMap{


### PR DESCRIPTION
Moving agenda specific hard-coded strings out of the template and into the go code. These should probably be moved into a config file eventually.

Also adds two new strings - `lnfeatures` and `fixlnseqlocks` in `friendlyAgendaLabels`