### PR TITLE
Remove more unused code

### DIFF
--- a/agenda.go
+++ b/agenda.go
@@ -23,7 +23,6 @@ type Agenda struct {
 	VoteCountPercentage     float64
 	BlockLockedIn           int64
 	BlockActivated          int64
-	BlockForked             int64
 }
 
 var dcpRE = regexp.MustCompile(`(?i)DCP\-?(\d{4})`)

--- a/main.go
+++ b/main.go
@@ -288,14 +288,12 @@ func updatetemplateInformation(dcrdClient *rpcclient.Client, latestBlockHeader *
 	templateInformation.Agendas = make([]Agenda, 0, len(getVoteInfo.Agendas))
 
 	for _, agenda := range getVoteInfo.Agendas {
-		log.Printf("getvoteinfo id: %#v", agenda)
 
 		// Check to see if all agendas are pending activation
 		if agenda.Status != "lockedin" {
 			templateInformation.PendingActivation = false
 		}
 		if agenda.Status != "active" {
-			log.Println(agenda.Status)
 			templateInformation.RulesActivated = false
 		}
 
@@ -317,7 +315,6 @@ func updatetemplateInformation(dcrdClient *rpcclient.Client, latestBlockHeader *
 		// ongoing basis.
 		var blockLockedIn int64
 		var blockActivated int64
-		var blockForked int64
 
 		choiceIdsActing := make([]string, 0, len(agenda.Choices)-1)
 		choicePercentagesActing := make([]float64, 0, len(agenda.Choices)-1)
@@ -325,30 +322,6 @@ func updatetemplateInformation(dcrdClient *rpcclient.Client, latestBlockHeader *
 		for _, choice := range agenda.Choices {
 			if !choice.IsAbstain {
 				choiceIdsActing = append(choiceIdsActing, choice.ID)
-				/*
-					if agenda.ID == "lnsupport" {
-						if choice.Id == "yes" {
-							choicePercentagesActing = append(choicePercentagesActing,
-								98.61)
-						} else if choice.Id == "no" {
-							choicePercentagesActing = append(choicePercentagesActing,
-								1.38)
-						}
-						blockLockedIn = 141184
-						blockActivated = 149248
-					} else if agenda.ID == "sdiffalgorithm" {
-						if choice.Id == "yes" {
-							choicePercentagesActing = append(choicePercentagesActing,
-								97.92)
-						} else if choice.Id == "no" {
-							choicePercentagesActing = append(choicePercentagesActing,
-								2.07)
-						}
-						blockLockedIn = 141184
-						blockActivated = 149248
-						blockForked = 149328
-					} else {
-				*/
 				choicePercentagesActing = append(choicePercentagesActing,
 					toFixed(choice.Progress/actingPct*100, 2))
 			}
@@ -371,7 +344,6 @@ func updatetemplateInformation(dcrdClient *rpcclient.Client, latestBlockHeader *
 			EndHeight:               getVoteInfo.EndHeight,
 			VoteCountPercentage:     toFixed(voteCountPercentage*100, 1),
 			BlockLockedIn:           blockLockedIn,
-			BlockForked:             blockForked,
 			BlockActivated:          blockActivated,
 		})
 	}

--- a/main.go
+++ b/main.go
@@ -263,7 +263,6 @@ func updatetemplateInformation(dcrdClient *rpcclient.Client, latestBlockHeader *
 	getVoteInfo, err := dcrdClient.GetVoteInfo(stakeVersion)
 	if err != nil {
 		log.Printf("Get vote info error: %v", err)
-		templateInformation.Quorum = false
 		return
 	}
 
@@ -284,11 +283,6 @@ func updatetemplateInformation(dcrdClient *rpcclient.Client, latestBlockHeader *
 		log.Printf("No agendas for vote version %d", mostPopularVersion)
 		templateInformation.Agendas = []Agenda{}
 		return
-	}
-
-	// Set Quorum to true since we got a valid response back from GetVoteInfoResult (?)
-	if getVoteInfo.TotalVotes >= getVoteInfo.Quorum {
-		templateInformation.Quorum = true
 	}
 
 	templateInformation.Agendas = make([]Agenda, 0, len(getVoteInfo.Agendas))

--- a/public/views/start.html
+++ b/public/views/start.html
@@ -371,12 +371,6 @@
                     <div class="agenda-voting-overview-option-block">Activated:</div>
                     <div class="agenda-voting-overview-option-block value">{{$agenda.BlockActivated}}</div>
                   </div>
-                  {{if ne $agenda.BlockForked 0}}
-                  <div class="agenda-voting-overview-option-active w-clearfix">
-                    <div class="agenda-voting-overview-option-block">Hard Forked:</div>
-                    <div class="agenda-voting-overview-option-block value">{{$agenda.BlockForked}}</div>
-                  </div>
-                  {{end}}
                 </div>
                 {{end}}
               </div>

--- a/template_fields.go
+++ b/template_fields.go
@@ -66,10 +66,6 @@ type templateFields struct {
 	// StakeVersionTimeRemaining is a string to show how much estimated time is remaining in the stake version interval.
 	StakeVersionTimeRemaining string
 
-	// Quorum and Rule Change Information
-	// Quorum is a bool that is true if needed number of yes/nos were
-	// received (>10%).
-	Quorum bool
 	// QuorumThreshold is the percentage required for the RuleChange to become active.
 	QuorumThreshold float64
 	// Length of the static rule change interval


### PR DESCRIPTION
- `Quorum` boolean is not used
- Unneeded console logging
- As it is currently written, the `BlockForked` functionality is only usable if the value is hard coded, **and** if historic agendas are displayed. Neither of these conditions are met at the moment, so the functionality is not working and the code is of little value. This should be very easy to re-implement properly if required in future.
- Remove the large comment with hard-coded historic vote data. This will be retrieved directly from the chain soon