### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,24 +7,48 @@ information about the tesnet hardfork voting.
 
 ## Developing
 
-``` bash
-go get -v github.com/golang/dep/cmd/dep
-go get -v github.com/decred/hardforkdemo
-cd $GOPATH/github.com/decred/hardforkdemo
-dep ensure
-go install
-```
 
-Start dcrd with the following options.  
+1. Install Go version 1.11 or higher, and Git.
+Make sure each of these are in the PATH.
+
+2. Clone this repository.
+    
+    2.1. If cloning under GOPATH
+    ``` bash
+    go get -v github.com/decred/hardforkdemo
+    cd $GOPATH/src/github.com/decred/hardforkdemo
+    ```
+
+    2.2 If not, just clone as a git repository.
+    ```bash
+    git clone https://github.com/decred/hardforkdemo
+    ```
+
+3. Install hardforkdemo
+
+    3.1. If building in a folder under GOPATH, it is necessary to explicitly build with modules enabled:
+
+    ``` bash
+    cd $GOPATH/src/github.com/decred/hardforkdemo
+    export GO111MODULE=on
+    go install
+    ```
+
+    3.2. If building outside of GOPATH, modules are automatically enabled, and go install is sufficient.
+    ``` bash
+    go install
+    ```
+
+4. Start dcrd with the following options.  
 
 ```bash
 dcrd --testnet -u USER -P PASSWORD --rpclisten=127.0.0.1:19109 --rpccert=$HOME/.dcrd/rpc.cert
 ```
 
-Start hardforkdemo
+Start hardforkdemo with the following options.  
 
 ```bash
-hardforkdemo
+hardforkdemo --testnet -u USER -P PASSWORD --rpccert ~/.dcrd/rpc.cert -c 127.0.0.1:19109
 ```
 
 ## Docker


### PR DESCRIPTION
This PR updates the README to use go 1.11 and adds the params to execute the hardforkdemo