### PR TITLE
Fix testnet explorer and faucet link.

### DIFF
--- a/config.go
+++ b/config.go
@@ -20,15 +20,16 @@ const (
 	defaultConfigFilename = "hardforkdemo.conf"
 )
 
-// Default network parameters
-var activeNetParams = &chaincfg.MainNetParams
-
 var (
+	// Default network parameters
+	activeNetParams *chaincfg.Params
+	// stakeVersion is the stake version we call getvoteinfo with.
+	stakeVersion uint32
+
 	// Default configuration options
 	defaultConfigFile  = filepath.Join(defaultHomeDir, defaultConfigFilename)
 	defaultHomeDir     = dcrutil.AppDataDir("hardforkdemo", false)
 	defaultRPCCertFile = filepath.Join(defaultHomeDir, "rpc.cert")
-	defaultRPCPort     = "9109"
 	defaultListenPort  = "8000"
 )
 
@@ -131,10 +132,19 @@ func loadConfig() (*config, error) {
 		return nil, err
 	}
 
+	var blockExplorerURL string
+	var defaultRPCPort string
+
 	if cfg.TestNet {
 		activeNetParams = &chaincfg.TestNet3Params
 		stakeVersion = stakeVersionTest
+		blockExplorerURL = "https://testnet.dcrdata.org"
 		defaultRPCPort = "19109"
+	} else {
+		activeNetParams = &chaincfg.MainNetParams
+		stakeVersion = stakeVersionMain
+		blockExplorerURL = "https://mainnet.dcrdata.org"
+		defaultRPCPort = "9109"
 	}
 
 	cfg.Listen = normalizeAddress(cfg.Listen, defaultListenPort)
@@ -153,7 +163,9 @@ func loadConfig() (*config, error) {
 
 	// Set all activeNetParams fields now that we know what network we are on.
 	templateInformation = &templateFields{
-		Network: activeNetParams.Name,
+		Network:          activeNetParams.Name,
+		BlockExplorerURL: blockExplorerURL,
+
 		// BlockVersion params
 		BlockVersionRejectThreshold: int(float64(activeNetParams.BlockRejectNumRequired) /
 			float64(activeNetParams.BlockUpgradeNumToCheck) * 100),

--- a/main.go
+++ b/main.go
@@ -47,8 +47,6 @@ const (
 )
 
 var (
-	// stakeVersion is the stake version we call getvoteinfo with.
-	stakeVersion uint32 = stakeVersionMain
 
 	// templateInformation is the template holding the active network
 	// parameters.
@@ -76,8 +74,6 @@ func updatetemplateInformation(dcrdClient *rpcclient.Client, latestBlockHeader *
 
 	// Set Current block height
 	templateInformation.BlockHeight = height
-	templateInformation.BlockExplorerLink = fmt.Sprintf("https://%s.dcrdata.org/block/%v",
-		activeNetParams.Name, hash)
 
 	templateInformation.FriendlyAgendaLabels = friendlyAgendaLabels
 	templateInformation.LongAgendaDescriptions = longAgendaDescriptions

--- a/public/views/start.html
+++ b/public/views/start.html
@@ -68,7 +68,7 @@
     <div class="header">
       <div class="header w-clearfix width-1180">
         <a class="header-logo w-inline-block" href="https://www.decred.org"></a>
-        {{if eq .Network "testnet"}}
+        {{if not (eq .Network "mainnet")}}
         <a class="header-link w-button" href="https://faucet.decred.org"> | &nbsp;Testnet Faucet</a>
         {{end}}
         {{if .IsUpgrading}}
@@ -108,7 +108,7 @@
           {{end}}
           -->
         {{end}}
-        <a class="header-link w-button" href="{{.BlockExplorerLink}}">Block #{{.BlockHeight}}</a>
+        <a class="header-link w-button" href="{{.BlockExplorerURL}}/block/{{.BlockHeight}}">Block #{{.BlockHeight}}</a>
       </div>
     </div>
     {{if .IsUpgrading}}

--- a/template_fields.go
+++ b/template_fields.go
@@ -18,8 +18,8 @@ type templateFields struct {
 
 	// Basic information
 	BlockHeight uint32
-	// Link to current block on explorer
-	BlockExplorerLink string
+	// Base URL for the block explorer
+	BlockExplorerURL string
 	// BlockVersion Information
 	//
 	// BlockVersions is the data after it has been prepared for graphing.


### PR DESCRIPTION
The code was expecting `&chaincfg.TestNet3Params.Name` to return `"testnet"` but it returns `"testnet3"`. As a result, the faucet link was not displayed and the block explorer link did not work when running in testnet mode. This fixes those two issues, as well as standardising where we set testnet/mainnet variables. They are now in one place rather than scattered.