### PR TITLE
Show vote results for historic agendas.

### DIFF
--- a/agenda.go
+++ b/agenda.go
@@ -6,21 +6,34 @@ package main
 
 import (
 	"html/template"
+	"log"
 	"regexp"
+
+	"github.com/decred/dcrd/dcrjson"
+	"github.com/decred/dcrd/rpcclient"
 )
 
 // Agenda contains all of the data representing an agenda for the html
 // template programming.
 type Agenda struct {
-	ID                      string
-	Status                  string
-	Description             string
-	QuorumVotedPercentage   float64
-	ChoiceIDsActing         []string
-	ChoicePercentagesActing []float64
-	StartHeight             int64
-	EndHeight               int64
-	VoteCountPercentage     float64
+	ID              string
+	Status          string
+	Description     string
+	Mask            uint16
+	VoteVersion     uint32
+	QuorumThreshold uint32
+	StartHeight     int64
+	EndHeight       int64
+	VoteChoices     map[string]VoteChoice
+	VoteCounts      map[string]uint32
+}
+
+// VoteChoice contains the details of a vote choice from an agenda,
+// Each agenda will have 3 choices - yes/no/maybe
+type VoteChoice struct {
+	ID          string
+	Description string
+	Bits        uint16
 }
 
 var dcpRE = regexp.MustCompile(`(?i)DCP\-?(\d{4})`)
@@ -68,10 +81,175 @@ func (a *Agenda) BlockActivated() int64 {
 	return -1
 }
 
+// TotalVotes returns the total number of No, Yes and Abstain votes cast against this agenda
+func (a *Agenda) TotalVotes() uint32 {
+	return a.VoteCounts["yes"] + a.VoteCounts["no"] + a.VoteCounts["abstain"]
+}
+
+// VotePercent returns the the number of yes/no/abstains votes, as a percentage of
+// all votes cast against this agenda
+func (a *Agenda) VotePercent(voteID string) float64 {
+	percent := float64(a.VoteCounts[voteID]) / float64(a.TotalVotes())
+	return toFixed(percent*100, 2)
+}
+
+// VoteCountPercentage returns the number of votes cast against this agenda as
+// a percentage of the theoretical maximum number of possible votes
+func (a *Agenda) VoteCountPercentage() float64 {
+	maxPossibleVotes := float64(activeNetParams.RuleChangeActivationInterval) * float64(activeNetParams.TicketsPerBlock)
+	voteCountPercentage := float64(a.TotalVotes()) / maxPossibleVotes
+	return toFixed(voteCountPercentage*100, 1)
+}
+
+// QuorumVotePercentage returns the total number of Yes and No votes as a
+// percentage of the quorum threshold.
+func (a *Agenda) QuorumVotePercentage() float64 {
+	quorumVotePercentage := float64(a.VoteCounts["yes"]+a.VoteCounts["no"]) / float64(a.QuorumThreshold)
+	return toFixed(quorumVotePercentage*100, 1)
+}
+
 // DescriptionWithDCPURL writes a new description with an link to any DCP that
 // is detected in the text.  It is written to a template.HTML type so the link
 // is not escaped when the template is executed.
 func (a *Agenda) DescriptionWithDCPURL() template.HTML {
 	subst := `<a href="https://github.com/decred/dcps/blob/master/dcp-${1}/dcp-${1}.mediawiki" target="_blank" rel="noopener noreferrer">${0}</a>`
 	return template.HTML(dcpRE.ReplaceAllString(a.Description, subst))
+}
+
+// CountVotes uses the dcrd client to find all yes/no/abstain votes
+// cast against this agenda. It will count the votes and store the
+// totals inside the Agenda
+func (a *Agenda) countVotes(dcrdClient *rpcclient.Client, votingStartHeight int64, votingEndHeight int64) error {
+	// Find the last block hash of this voting period
+	// Required to call GetStakeVersions
+	lastBlockHash, err := dcrdClient.GetBlockHash(votingEndHeight)
+	if err != nil {
+		return err
+	}
+
+	// Retrieve all votes for this voting period
+	stakeVersions, err := dcrdClient.GetStakeVersions(lastBlockHash.String(), int32(votingEndHeight-votingStartHeight))
+	if err != nil {
+		return err
+	}
+
+	// Collect all votes of the correct version
+	var votes []dcrjson.VersionBits
+	for _, sVer := range stakeVersions.StakeVersions {
+		for _, vote := range sVer.Votes {
+			if vote.Version == a.VoteVersion {
+				votes = append(votes, vote)
+			}
+		}
+	}
+
+	// Count the votes and store the total
+	for vID := range a.VoteChoices {
+		var matchingVotes uint32
+		for _, vote := range votes {
+			if vote.Bits&a.Mask == a.VoteChoices[vID].Bits {
+				matchingVotes++
+			}
+		}
+		a.VoteCounts[vID] = matchingVotes
+		log.Printf("\t%s: %d", vID, matchingVotes)
+	}
+
+	return nil
+}
+
+// agendasFromJSON parses the response from GetVoteInfo, and
+// uses the data to create a set of Agenda objects
+func agendasFromJSON(getVoteInfo dcrjson.GetVoteInfoResult) []Agenda {
+	var parsedAgendas []Agenda
+	for _, a := range getVoteInfo.Agendas {
+		voteChoices := make(map[string]VoteChoice)
+		for _, choice := range a.Choices {
+			vote := VoteChoice{
+				ID:          choice.ID,
+				Description: choice.Description,
+				Bits:        choice.Bits,
+			}
+			voteChoices[vote.ID] = vote
+		}
+		parsedAgendas = append(parsedAgendas, Agenda{
+			ID:              a.ID,
+			Status:          a.Status,
+			Description:     a.Description,
+			Mask:            a.Mask,
+			VoteVersion:     getVoteInfo.VoteVersion,
+			QuorumThreshold: getVoteInfo.Quorum,
+			VoteChoices:     voteChoices,
+			VoteCounts:      make(map[string]uint32),
+		})
+	}
+	return parsedAgendas
+}
+
+func agendasForVersions(dcrdClient *rpcclient.Client, versions []uint32, currentHeight int64, svis StakeVersionIntervals) ([]Agenda, error) {
+	var allAgendas []Agenda
+	for _, version := range versions {
+		// Retrieve Agendas for this voting period
+		getVoteInfo, err := dcrdClient.GetVoteInfo(version)
+		if err != nil {
+			return nil, err
+		}
+		agendas := agendasFromJSON(*getVoteInfo)
+
+		// Check if upgrade to this version has occurred yet
+		upgradeOccurred, upgradeHeight := svis.GetStakeVersionUpgradeHeight(version)
+
+		if !upgradeOccurred {
+			// Haven't upgraded to this stake version yet. Therefore
+			// we dont know when the voting start/end heights will be.
+			// Nothing more to do with these agendas
+			log.Printf("Upgrade to stake version %d has not happened", version)
+			allAgendas = append(allAgendas, agendas...)
+			break
+		}
+
+		log.Printf("Upgrade to version %d happened at height %d", version, upgradeHeight)
+
+		// Find the start of the next RCI after the threshold was met
+		nextRCIStartHeight := activeNetParams.StakeValidationHeight
+		for nextRCIStartHeight < upgradeHeight {
+			nextRCIStartHeight += int64(activeNetParams.RuleChangeActivationInterval)
+		}
+
+		// Next RCI height tells us the voting start/end heights, and we can add these to the agendas
+		votingStartHeight := nextRCIStartHeight
+		votingEndHeight := nextRCIStartHeight + int64(activeNetParams.RuleChangeActivationInterval) - 1
+		for _, agenda := range agendas {
+			agenda.StartHeight = votingStartHeight
+			agenda.EndHeight = votingEndHeight
+			log.Printf("Voting on %s will occur between %d-%d", agenda.ID, votingStartHeight, votingEndHeight)
+		}
+
+		if votingStartHeight > currentHeight {
+			// Voting hasnt started yet. So we cannot count the votes.
+			// Nothing more to do with these agendas
+			log.Printf("Voting is in the future so not counting votes yet")
+			allAgendas = append(allAgendas, agendas...)
+			break
+		}
+
+		// If agenda voting is currently in progress, only check votes up to the latest block
+		if votingEndHeight > currentHeight {
+			log.Printf("Voting is currently on-going")
+			votingEndHeight = currentHeight
+		}
+
+		// Count votes and store totals within Agenda struct
+		for _, agenda := range agendas {
+			log.Printf("Counting votes for %s between blocks %d-%d",
+				agenda.ID, votingStartHeight, votingEndHeight)
+			err = agenda.countVotes(dcrdClient, votingStartHeight, votingEndHeight)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		allAgendas = append(allAgendas, agendas...)
+	}
+	return allAgendas, nil
 }

--- a/config.go
+++ b/config.go
@@ -25,6 +25,8 @@ var (
 	activeNetParams *chaincfg.Params
 	// stakeVersion is the stake version we call getvoteinfo with.
 	stakeVersion uint32
+	// the vote versions which include agendas
+	voteVersions []uint32
 
 	// Default configuration options
 	defaultConfigFile  = filepath.Join(defaultHomeDir, defaultConfigFilename)
@@ -138,11 +140,13 @@ func loadConfig() (*config, error) {
 	if cfg.TestNet {
 		activeNetParams = &chaincfg.TestNet3Params
 		stakeVersion = stakeVersionTest
+		voteVersions = voteVersionsTest
 		blockExplorerURL = "https://testnet.dcrdata.org"
 		defaultRPCPort = "19109"
 	} else {
 		activeNetParams = &chaincfg.MainNetParams
 		stakeVersion = stakeVersionMain
+		voteVersions = voteVersionsMain
 		blockExplorerURL = "https://mainnet.dcrdata.org"
 		defaultRPCPort = "9109"
 	}

--- a/public/css/decred-hardforkwebsite.css
+++ b/public/css/decred-hardforkwebsite.css
@@ -1463,6 +1463,11 @@ body {
   background-color: #596d81;
 }
 
+#agendalisting{
+  display: flex;
+  flex-flow: column;
+}
+
 .agenda {
   position: relative;
   width: 100%;
@@ -1474,12 +1479,8 @@ body {
   color: #09182d;
 }
 
-.agenda.drop-shadow-first-element {
+.agenda.drop-shadow {
   box-shadow: 0 4px 10px 0 rgba(0, 0, 0, .2);
-}
-
-.agenda.drop-shadow-n-element {
-  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, .2);
 }
 
 .header-logo {
@@ -2313,32 +2314,16 @@ body {
   border-radius: 50%;
 }
 
-.agenda-voting-overview-option-dot._1 {
+.agenda-voting-overview-option-dot._yes {
   background-color: #2971ff;
 }
 
-.agenda-voting-overview-option-dot._2 {
+.agenda-voting-overview-option-dot._no {
   background-color: #2ed6a1;
 }
 
-.agenda-voting-overview-option-dot._3 {
+.agenda-voting-overview-option-dot._abstain {
   background-color: #fd714b;
-}
-
-.agenda-voting-overview-option-dot._4 {
-  background-color: #69d3f5;
-}
-
-.agenda-voting-overview-option-dot._5 {
-  background-color: #2252a1;
-}
-
-.agenda-voting-overview-option-dot._6 {
-  background-color: #c4cbd2;
-}
-
-.agenda-voting-overview-option-dot.n {
-  background-color: #000;
 }
 
 .agenda-voting-overview-option-percent {
@@ -2688,9 +2673,6 @@ body {
     padding-right: 50px;
     padding-bottom: 30px;
     padding-left: 50px;
-  }
-  .agenda.drop-shadow-first-element {
-    margin-top: 20px;
   }
   .chart-toggle-side {
     display: none;

--- a/public/views/start.html
+++ b/public/views/start.html
@@ -46,10 +46,9 @@
 
   {{range $i, $agenda := .Agendas}}
     {{if or $agenda.IsStarted $agenda.IsActive $agenda.IsLockedIn $agenda.IsFailed }}
-      {{range $cid, $choice := .ChoiceIDsActing}}
-      {{$cid1 := plus $cid 1}}
-  .option-progress.a_{{$agenda.ID}}-c{{$choice}} {
-  width: {{index $agenda.ChoicePercentagesActing $cid}}%;
+      {{range $cid, $choice := $agenda.VoteChoices}}	
+  .option-progress.a_{{$agenda.ID}}-c{{$choice.ID}} {
+  width: {{$agenda.VotePercent $choice.ID}}%;	
   }
       {{end}}
     {{end}}
@@ -249,12 +248,7 @@
 
 <!-- agenda loop start -->
     {{range $i, $agenda := .Agendas}}
-        {{if or $agenda.IsActive $agenda.IsLockedIn $agenda.IsFailed }}
-        <div class="agenda drop-shadow-n-element w-clearfix">
-        {{end}}
-        {{if or $agenda.IsDefined $agenda.IsStarted}}
-        <div class="agenda drop-shadow-first-element w-clearfix">
-        {{end}}
+        <div class="agenda drop-shadow w-clearfix" style="order: -{{$agenda.VoteVersion}};">
           <div class="agenda-section w-clearfix">
             <div class="agenda-indicator w-clearfix">
               <!-- labels -->
@@ -348,19 +342,16 @@
               </div>
               <div class="agenda-voting-overview-options w-clearfix">
                 <div class="width-third">
-                  {{range $cid, $choice := .ChoiceIDsActing}}
-                  {{$cid1 := plus $cid 1}}
+                  {{range $cid, $choice := $agenda.VoteChoices}}
                   <div class="agenda-voting-overview-option w-clearfix">
-                    <div class="_{{$cid1}} agenda-voting-overview-option-dot"></div>
-                    <div class="agenda-voting-overview-option-percent" data-tooltip-text="">{{$choice}}</div>
-                    {{if or $agenda.IsStarted $agenda.IsActive $agenda.IsLockedIn $agenda.IsFailed }} <div class="agenda-voting-overview-option-percent value">{{index $agenda.ChoicePercentagesActing $cid}}%</div>{{end}}
+                    <div class="_{{$choice.ID}} agenda-voting-overview-option-dot"></div>
+                    <div class="agenda-voting-overview-option-percent" data-tooltip-text="">{{$choice.ID}}</div>
+                    {{if or $agenda.IsStarted $agenda.IsActive $agenda.IsLockedIn $agenda.IsFailed }} <div class="agenda-voting-overview-option-percent value">{{$agenda.VotePercent $choice.ID}}%</div>{{end}}
                   </div>
-                  {{if modiszero $cid1 3}}
-                </div>
-                <div class="width-third">
                   {{end}}
-                  {{end}}
-                </div>
+                  </div>
+                  <div class="width-third">
+                  </div>
                 {{if $agenda.IsActive}}
                 <div class="width-half">
                   <div class="agenda-voting-overview-option-active w-clearfix">
@@ -417,9 +408,8 @@
             <div class="progress-bar-agenda w-clearfix">
               <div class="progress-bar-competing-options-and-total-votes w-clearfix">
                 <div class="progress-bar-competing-options w-clearfix" style="width:{{if gt $agenda.VoteCountPercentage 50.00}}{{$agenda.VoteCountPercentage}}{{else}}{{50}}{{end}}%">
-                  {{range $cid, $choice := .ChoiceIDsActing}}
-                  {{$cid1 := plus $cid 1}}
-                  <div class="option-{{$cid1}} option-progress a_{{$agenda.ID}}-c{{$choice}}" data-tooltip-text="{{$choice}}" data-tooltip-value="{{index $agenda.ChoicePercentagesActing $cid}}"></div>
+                  {{range $cid, $choice := $agenda.VoteChoices}}
+                  <div class="option-{{$choice.ID}} option-progress a_{{$agenda.ID}}-c{{$choice.ID}}" data-tooltip-text="{{$choice.ID}}" data-tooltip-value="{{$agenda.VotePercent $choice.ID}}"></div>
                   {{end}}
                 </div>
                 <!-- <div class="total-votes-cast" data-tooltip-text="Total Votes Cast" data-tooltip-value="0"></div> -->

--- a/stake_version_intervals.go
+++ b/stake_version_intervals.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"log"
+
+	"github.com/decred/dcrd/dcrjson"
+	"github.com/decred/dcrd/rpcclient"
+)
+
+// StakeVersionIntervals wraps a set of dcrjson.VersionIntervals
+type StakeVersionIntervals struct {
+	Intervals []dcrjson.VersionInterval
+}
+
+// GetStakeVersionUpgradeHeight will search through every stake version interval
+// to find the first SVI which meets the upgrade threshold for the provided version.
+// It then returns the end height of that SVI.
+func (s *StakeVersionIntervals) GetStakeVersionUpgradeHeight(version uint32) (bool, int64) {
+	for i, svi := range s.Intervals {
+		var totalVotes int32
+		var versionVotes int32
+		for _, voteVersion := range svi.VoteVersions {
+			totalVotes = totalVotes + int32(voteVersion.Count)
+			if voteVersion.Version == version {
+				versionVotes = versionVotes + int32(voteVersion.Count)
+			}
+		}
+		upgradeThreshold := totalVotes * activeNetParams.StakeMajorityMultiplier / activeNetParams.StakeMajorityDivisor
+		if versionVotes > upgradeThreshold {
+			log.Printf("v%d upgrade threshold was met during SVI %d (blocks %d-%d). Total votes: %d, v%d votes: %d, threshold: %d",
+				version, i+1, svi.StartHeight, svi.EndHeight, totalVotes, version, versionVotes, upgradeThreshold)
+			return true, svi.EndHeight
+		}
+	}
+	return false, -1
+}
+
+// AllStakeVersionIntervals uses the dcrd client to create an ordered
+// set of objects representing every Stake Version Interval up to the
+// provided block height
+func AllStakeVersionIntervals(dcrdClient *rpcclient.Client, height int64) (StakeVersionIntervals, error) {
+	// Use current height to calculate the number of the current SVI
+	totalSVIs := 1 + int32((height-activeNetParams.StakeValidationHeight)/activeNetParams.StakeVersionInterval)
+
+	// Get SVIs details from dcrd
+	stakeVersionInfoResult, err := dcrdClient.GetStakeVersionInfo(totalSVIs)
+	if err != nil {
+		return StakeVersionIntervals{}, err
+	}
+
+	svis := StakeVersionIntervals{
+		Intervals: stakeVersionInfoResult.Intervals}
+
+	// Reverse the slice of SVIs
+	// This makes traversing the set easier later on,
+	// because the first element is the first SVI, etc.
+	for i := len(svis.Intervals)/2 - 1; i >= 0; i-- {
+		opp := len(svis.Intervals) - 1 - i
+		svis.Intervals[i], svis.Intervals[opp] = svis.Intervals[opp], svis.Intervals[i]
+	}
+
+	return svis, nil
+}


### PR DESCRIPTION
The agenda details on the html template are populated using an Agenda object. This PR removes the logic which creates that Agenda object, and replaces it with logic which can create an Agenda object for **every** agenda, not just the current one.

At the moment the code favours readability and maintainability over run-time efficiency, as it will only be executed once at startup and once each time a block is discovered.

Unfortunately the implementation currently depends on the historic vote versions to be hard coded, but this is an improvement over the previous situation where the full vote results were hardcoded. These can be extracted to config or derived using dcrd in a later PR.

Closes #204 