### PR TITLE
 Fix vote progress.

### DIFF
--- a/agenda.go
+++ b/agenda.go
@@ -65,6 +65,12 @@ func (a *Agenda) IsFailed() bool {
 	return a.Status == "failed"
 }
 
+// QuorumMet indicates if the total number of yes/note
+// votes has surpassed the quorum threshold
+func (a *Agenda) QuorumMet() bool {
+	return a.VoteCounts["yes"]+a.VoteCounts["no"] >= a.QuorumThreshold
+}
+
 // BlockLockedIn returns the height of the first block of this agenda's lock-in period. -1 if this agenda has not been locked-in.
 func (a *Agenda) BlockLockedIn() int64 {
 	if a.IsLockedIn() || a.IsActive() {
@@ -99,13 +105,6 @@ func (a *Agenda) VoteCountPercentage() float64 {
 	maxPossibleVotes := float64(activeNetParams.RuleChangeActivationInterval) * float64(activeNetParams.TicketsPerBlock)
 	voteCountPercentage := float64(a.TotalVotes()) / maxPossibleVotes
 	return toFixed(voteCountPercentage*100, 1)
-}
-
-// QuorumVotePercentage returns the total number of Yes and No votes as a
-// percentage of the quorum threshold.
-func (a *Agenda) QuorumVotePercentage() float64 {
-	quorumVotePercentage := float64(a.VoteCounts["yes"]+a.VoteCounts["no"]) / float64(a.QuorumThreshold)
-	return toFixed(quorumVotePercentage*100, 1)
 }
 
 // DescriptionWithDCPURL writes a new description with an link to any DCP that

--- a/main.go
+++ b/main.go
@@ -78,7 +78,7 @@ func updatetemplateInformation(dcrdClient *rpcclient.Client, latestBlockHeader *
 	log.Printf("Current best block height: %d", height)
 
 	// Set Current block height
-	templateInformation.BlockHeight = height
+	templateInformation.BlockHeight = int64(height)
 
 	templateInformation.FriendlyAgendaLabels = friendlyAgendaLabels
 	templateInformation.LongAgendaDescriptions = longAgendaDescriptions

--- a/public/css/decred-hardforkwebsite.css
+++ b/public/css/decred-hardforkwebsite.css
@@ -1770,17 +1770,17 @@ body {
   background-color: #000;
 }
 
-.option-progress.option-1 {
+.option-progress.option-yes {
   width: 63%;
   background-color: #2971ff;
 }
 
-.option-progress.option-2 {
+.option-progress.option-no {
   width: 30%;
   background-color: #2ed6a1;
 }
 
-.option-progress.option-3 {
+.option-progress.option-abstain {
   width: 7%;
   background-color: #fd714b;
 }
@@ -1792,15 +1792,6 @@ body {
   height: 10px;
   border-radius: 5px;
   background-color: #596d81;
-}
-
-.progress-bar-competing-options {
-  position: relative;
-  overflow: hidden;
-  width: 50%;
-  height: 100%;
-  float: left;
-  border-radius: 5px;
 }
 
 .text-block.voting-overview {

--- a/public/views/start.html
+++ b/public/views/start.html
@@ -299,7 +299,7 @@
               <!-- quorum indicator -->
               {{if $agenda.IsStarted}}
               <div class="quorum w-clearfix">Quorum: &nbsp;
-                {{if eq $agenda.QuorumProgress 1.0}}
+                {{if $agenda.QuorumMet}}
                 <span class="highlight-text green transparent quorum">Yes</span>
                 {{else}}
                 <span class="highlight-text orange transparent quorum">No</span>
@@ -372,7 +372,7 @@
                 {{end}}
 
                 {{if $agenda.IsStarted}}
-                  {{if eq $agenda.QuorumProgress 1.0}}
+                  {{if $agenda.QuorumMet}}
                     <!-- <div class="agenda-voting-overview-disclaimer">
                     <p><small><strong>Success!</strong><br />We have reached the minimum Quorum of {{$.QuorumThreshold}}% actively made votes.<br />
                     There are <strong>{{minus64 $agenda.EndHeight $.BlockHeight}}</strong> blocks left in the vote.</small>
@@ -402,17 +402,14 @@
           </div>
 
           <!-- agenda voting results barchart -->
-          {{if or $agenda.IsStarted }}
+          {{if $agenda.IsStarted }}
           <div class="agenda-section progress-bar w-clearfix">
             <div class="progress-bar-agenda w-clearfix">
               <div class="progress-bar-competing-options-and-total-votes w-clearfix">
-                <div class="progress-bar-competing-options w-clearfix" style="width:{{if gt $agenda.VoteCountPercentage 50.00}}{{$agenda.VoteCountPercentage}}{{else}}{{50}}{{end}}%">
                   {{range $cid, $choice := $agenda.VoteChoices}}
                   <div class="option-{{$choice.ID}} option-progress a_{{$agenda.ID}}-c{{$choice.ID}}" data-tooltip-text="{{$choice.ID}}" data-tooltip-value="{{$agenda.VotePercent $choice.ID}}"></div>
                   {{end}}
-                </div>
               </div>
-              <!-- <div class="agenda progress-bar-threshold"></div> -->
               <div class="heading progress-bar-agenda-voting-percent">{{$agenda.VoteCountPercentage }}%</div>
             </div>
           </div>
@@ -424,7 +421,7 @@
           <div class="agenda-voting-begins">Starts in {{minus64 $agenda.EndHeight $.BlockHeight}} blocks</div>
           {{end}}
           {{if $agenda.IsStarted}}
-            {{if eq $agenda.QuorumProgress 1.0}}
+            {{if $agenda.QuorumMet}}
               <div class="agenda-voting-begins">Quorum achieved
               </div>
             {{else}}

--- a/template_fields.go
+++ b/template_fields.go
@@ -17,7 +17,7 @@ type templateFields struct {
 	Network string
 
 	// Basic information
-	BlockHeight uint32
+	BlockHeight int64
 	// Base URL for the block explorer
 	BlockExplorerURL string
 	// BlockVersion Information


### PR DESCRIPTION
The testnet vote is currently in progress, but it is not being displayed at all because of a call to non-existent method `QuorumProgress` causing the template render to crash:

I have implemented a `QuorumMet` method which returns a bool to fix this feature.

This PR also removes `QuorumVotePercentage` from `agenda.go`. I copied it blindly from `web.go` into `agenda.go` when I was moving things around, however I have just realised it is not used at all.