### PR TITLE
Recognise PoS upgrades in previous SVIs.

### DIFF
--- a/public/css/decred-hardforkwebsite.css
+++ b/public/css/decred-hardforkwebsite.css
@@ -1636,7 +1636,7 @@ body {
   position: relative;
   width: 100%;
   height: 60px;
-  margin-top: 20px;
+  margin-top: auto;
   padding-top: 25px;
   padding-bottom: 25px;
 }
@@ -1889,6 +1889,8 @@ body {
 }
 
 .upgrade-content {
+  display: flex;
+  flex-flow: column;
   position: relative;
   left: 0px;
   top: 0px;

--- a/public/views/start.html
+++ b/public/views/start.html
@@ -191,7 +191,9 @@
             <div class="upgrade-content-statistics-main w-clearfix">
               <div class="upgrade-content-statistics-numbers w-clearfix">Current Version:
                 <span class="highlight-text {{if .StakeVersionSuccess}}green{{else}}orange{{end}}">v{{.StakeVersionCurrent}}</span>
-                <br> Next Version: <span class="highlight-text {{if .StakeVersionSuccess}}green{{else}}orange{{end}}">v{{.StakeVersionMostPopular}}</span>
+                {{if not .StakeVersionSuccess}}
+                <br> Next Version: <span class="highlight-text orange">v{{.StakeVersionMostPopular}}</span>
+                {{end}}
                 <br> Upgrade Threshold: <span class="highlight-text">{{.StakeVersionThreshold}}%</span>
                 <br> Upgrade Interval: <span class="highlight-text">{{.StakeVersionIntervalBlocks}}</span>
               </div>
@@ -219,7 +221,10 @@
               <div class="headingsubline">Proof-of-Stake</div>
               <div class="chart-statistics-numbers upgrade-content-statistics-numbers w-clearfix">Current Version:
                 <span class="highlight-text {{if .StakeVersionSuccess}}green{{else}}orange{{end}}">v{{.StakeVersionCurrent}}</span>
-                <br> Next Version: <span class="highlight-text {{if .StakeVersionSuccess}}green{{else}}orange{{end}}">v{{.StakeVersionMostPopular}}</span>
+                {{if not .StakeVersionSuccess}}
+                <br> Next Version: <span
+                  class="highlight-text orange">v{{.StakeVersionMostPopular}}</span>
+                {{end}}
                 <br> Upgrade Threshold: <span class="highlight-text">{{.StakeVersionThreshold}}%</span>
                 <br> Upgrade Interval: <span class="highlight-text">{{.StakeVersionIntervalBlocks}}</span>
               </div>

--- a/template_fields.go
+++ b/template_fields.go
@@ -17,7 +17,7 @@ type templateFields struct {
 	Network string
 
 	// Basic information
-	BlockHeight uint32
+	BlockHeight int64
 	// Base URL for the block explorer
 	BlockExplorerURL string
 	// BlockVersion Information


### PR DESCRIPTION
On testnet the upgrade to vote version 7 has already occurred, but hardforkdemo does not realise this because it is currently hardcoded to only look at the votes in the current SVI.

This PR enables hardforkdemo to check if the upgrade already took place in a previous SVI.