### PR TITLE
Round down div widths to prevent overlap.

### DIFF
--- a/public/views/start.html
+++ b/public/views/start.html
@@ -48,7 +48,7 @@
     {{if or $agenda.IsStarted $agenda.IsActive $agenda.IsLockedIn $agenda.IsFailed }}
       {{range $cid, $choice := $agenda.VoteChoices}}	
   .option-progress.a_{{$agenda.ID}}-c{{$choice.ID}} {
-  width: {{$agenda.VotePercent $choice.ID}}%;	
+  width: {{roundDown ($agenda.VotePercent $choice.ID)}}%;
   }
       {{end}}
     {{end}}

--- a/web.go
+++ b/web.go
@@ -16,6 +16,11 @@ var funcMap = template.FuncMap{
 	"minus":     minus,
 	"minus64":   minus64,
 	"modiszero": modiszero,
+	"roundDown": roundDown,
+}
+
+func roundDown(a float64) float64 {
+	return math.Floor(a*10) / 10
 }
 
 func plus(a, b int) int {


### PR DESCRIPTION
I just noticed a situation where the total of yes/no/abstain votes on the progress bar was overlapping onto  a second row because their total width was greater than 100.

This PR adjusts the width of the divs to use a floor value so the total width will always be below 100 (but only by an imperceptible amount)