### PR TITLE
Seperate progress message from progress bar.

### DIFF
--- a/public/css/decred-hardforkwebsite.css
+++ b/public/css/decred-hardforkwebsite.css
@@ -1648,14 +1648,13 @@ body {
   line-height: 17px;
 }
 
-.heading.blocks-left-for-voting {
-  position: absolute;
+.blocks-left-for-voting {
   display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
   align-items: center;
-  top: 0px;
-  right: 0px;
   color: #0c1e3e;
-  padding-bottom: 10px;
+  padding: 10px;
 }
 
 .blocks-left-for-voting-dot {
@@ -1691,13 +1690,6 @@ body {
   margin-top: 0px;
   margin-bottom: 9px;
   padding: 0px;
-}
-
-.progress-bar-agenda {
-  position: relative;
-  height: 60px;
-  padding-top: 25px;
-  padding-bottom: 25px;
 }
 
 .option-progress {
@@ -2090,11 +2082,9 @@ body {
 
 .agenda-section {
   width: 100%;
-  float: left;
-  clear: left;
 }
 
-.agenda-section.progress-bar {
+.agenda-section.progresss-bar {
   margin-top: 20px;
   float: left;
   clear: left;

--- a/public/views/start.html
+++ b/public/views/start.html
@@ -325,7 +325,6 @@
 
             <!-- agenda choices list -->
             <div class="left-padding-50 w-clearfix width-half">
-              {{if not $agenda.IsLockedIn}}
               <div class="agenda-voting-overview-options-title w-clearfix">
                 <div class="agenda-voting-overview">
                 {{if $agenda.IsActive}}voting results:{{else}}voting overview:{{end}}</div>
@@ -336,7 +335,9 @@
                   <div class="agenda-voting-overview-option w-clearfix">
                     <div class="_{{$choice.ID}} agenda-voting-overview-option-dot"></div>
                     <div class="agenda-voting-overview-option-percent">{{$choice.ID}}</div>
-                    {{if or $agenda.IsStarted $agenda.IsActive $agenda.IsLockedIn $agenda.IsFailed }} <div class="agenda-voting-overview-option-percent value">{{$agenda.VotePercent $choice.ID}}%</div>{{end}}
+                    {{if or $agenda.IsStarted $agenda.IsActive $agenda.IsLockedIn $agenda.IsFailed }}
+                      <div class="agenda-voting-overview-option-percent value">{{$agenda.VotePercent $choice.ID}}%</div>
+                    {{end}}
                   </div>
                   {{end}}
                   </div>
@@ -353,7 +354,6 @@
                 </div>
                 {{end}}
               </div>
-              {{end}}
                 {{if and $.StakeVersionSuccess $.BlockVersionSuccess $agenda.IsDefined}}
                 <div class="agenda-voting-overview-disclaimer">
                 <p><small>Blocks left {{if $agenda.IsStarted}}for{{else}}until{{end}} voting: {{minus64 $agenda.EndHeight $.BlockHeight}}</small></p>
@@ -390,10 +390,17 @@
             </div>
           </div>
 
+          {{if $agenda.IsStarted }}
+          <div class="blocks-left-for-voting">
+            <div class="blocks-left-for-voting-dot"></div>
+            <div class="heading">{{minus64 $agenda.EndHeight $.BlockHeight}} blocks left for voting</div>
+          </div>
+          {{end}}
+
           <!-- agenda voting results barchart -->
           {{if $agenda.IsStarted }}
           <div class="agenda-section progress-bar w-clearfix">
-            <div class="progress-bar-agenda w-clearfix">
+            <div class="w-clearfix">
               <div class="progress-bar-competing-options-and-total-votes w-clearfix">
                   {{range $cid, $choice := $agenda.VoteChoices}}
                   <div class="option-{{$choice.ID}} option-progress a_{{$agenda.ID}}-c{{$choice.ID}}">
@@ -404,10 +411,6 @@
                     </div>
                   </div>
                   {{end}}
-              </div>
-              <div class="heading blocks-left-for-voting">
-                <div class="blocks-left-for-voting-dot"></div>
-                {{minus64 $agenda.EndHeight $.BlockHeight}} blocks left for voting
               </div>
             </div>
           </div>


### PR DESCRIPTION
Seperating the message from the bar allows us to reuse the message later without the bar being displayed. It also removes some nasty absolute positioning.

Also, for some reason, the vote results were not being showed when agenda status == lockedin. I have updated this so the results will always be shown
