### PR TITLE
Fix overlapping agenda titles.

### DIFF
--- a/public/css/decred-hardforkwebsite.css
+++ b/public/css/decred-hardforkwebsite.css
@@ -215,7 +215,6 @@ body {
 }
 
 .width-half.left-padding-50 {
-  padding-top: 30px;
   padding-left: 50px;
 }
 
@@ -1466,7 +1465,6 @@ body {
     width: 100%;
   }
   .width-half.left-padding-50 {
-    padding-top: 20px;
     padding-left: 0px;
   }
   .width-third {
@@ -1519,9 +1517,6 @@ body {
   }
   .icon {
     margin-top: 12px;
-  }
-  .width-half.left-padding-50 {
-    padding-top: 30px;
   }
   .width-third {
     width: 100%;

--- a/public/views/start.html
+++ b/public/views/start.html
@@ -234,6 +234,9 @@
     {{range $i, $agenda := .Agendas}}
         <div class="agenda drop-shadow w-clearfix" style="order: -{{$agenda.VoteVersion}};">
           <div class="agenda-section w-clearfix">
+            <div class="agenda heading">
+              {{index $.FriendlyAgendaLabels $agenda.ID}}
+            </div>
             <div class="agenda-indicator w-clearfix">
               <!-- labels -->
               {{if $agenda.IsDefined}}
@@ -301,9 +304,6 @@
 
             <!-- agenda details -->
             <div class="w-clearfix width-half">
-              <div class="agenda heading">
-                {{index $.FriendlyAgendaLabels $agenda.ID}}
-              </div>
               <div class="agenda-cfg w-clearfix">
                 <div class="agenda-cfg-spec w-clearfix">Agenda ID: &nbsp;<span class="highlight-text cyan transparent">#{{$agenda.ID}}</span>
                 </div>


### PR DESCRIPTION
Issue reported by @dajohi . With certain page widths, the agenda title would overlap the elements underneath.