### PR TITLE
Improve disclaimer line for agendas about to start or in progress.

### DIFF
--- a/agenda.go
+++ b/agenda.go
@@ -95,11 +95,6 @@ func (a *Agenda) ActivationBlock() int64 {
 	return -1
 }
 
-// TimeUntilActivation returns the approximate time left until this agenda becomes activated
-func (a *Agenda) TimeUntilActivation(currentHeight int64) string {
-	return blocksToTimeEstimate(a.ActivationBlock() - currentHeight)
-}
-
 // TotalVotes returns the total number of No, Yes and Abstain votes cast against this agenda
 func (a *Agenda) TotalVotes() int64 {
 	return a.VoteCounts["yes"] + a.VoteCounts["no"] + a.VoteCounts["abstain"]

--- a/public/css/hardforkdemo.css
+++ b/public/css/hardforkdemo.css
@@ -1085,22 +1085,6 @@ body {
 
 .agenda-voting-overview-disclaimer {
   clear:both;
-  padding: 5px;
-  width: 66%; 
-  font-size: 14px;
-  background-color: #d1f2fc;
-  border-radius: 3px;
-}
-
-.agenda-voting-overview-disclaimer-lockedin {
-  clear:both;
-  padding: 10px;
-  font-size: 17px;
-  background-color: #d1f2fc;
-  border-radius: 3px;
-}
-.agenda-voting-overview-disclaimer-activated {
-  clear:both;
   padding: 10px;
   font-size: 17px;
   background-color: #d1f2fc;

--- a/public/views/start.html
+++ b/public/views/start.html
@@ -403,39 +403,26 @@
                     {{end}}
                   </div>
                 </div>
-                {{if and $.PosUpgrade.Completed $.BlockVersionSuccess $agenda.IsDefined}}
-                <div class="agenda-voting-overview-disclaimer">
-                <p><small>Blocks left {{if $agenda.IsStarted}}for{{else}}until{{end}} voting: {{if $agenda.IsStarted}}{{commaSeparate (minus64 $agenda.EndHeight $.BlockHeight)}}{{else}}{{commaSeparate (minus64 $agenda.StartHeight $.BlockHeight)}}{{end}}</small></p>
-                </div>
-                {{end}}
 
-                {{if $agenda.IsStarted}}
-                  {{if $agenda.QuorumMet}}
-                    <!-- <div class="agenda-voting-overview-disclaimer">
-                    <p><small><strong>Success!</strong><br />We have reached the minimum Quorum of {{$.QuorumThreshold}}% actively made votes.<br />
-                    There are <strong>{{minus64 $agenda.EndHeight $.BlockHeight}}</strong> blocks left in the vote.</small>
-                    </p>
-                    </div> -->
-                  {{else}}
-                  <!--
-                    <div class="agenda-voting-overview-disclaimer">
-                    <p>We have yet not reached the minimum Quorum of {{$.QuorumThreshold}}% actively made votes.
-                    </p>
-                    </div> -->
+                <div class="agenda-voting-overview-disclaimer">
+                <p><small>
+                  {{if and $.PosUpgrade.Completed $.BlockVersionSuccess $agenda.IsDefined}}
+                    Approximately <strong>{{blocksToTimeEstimate $agenda.StartHeight $.BlockHeight}}</strong> until voting starts ({{commaSeparate (minus64 $agenda.StartHeight $.BlockHeight)}} blocks).
                   {{end}}
-                {{end}}
-                {{if $agenda.IsLockedIn}}
-                    <div class="agenda-voting-overview-disclaimer-lockedin">
-                    <p><small>The vote has passed! The new rules will be activated in approximately <strong>{{$agenda.TimeUntilActivation $.BlockHeight}}</strong> ({{commaSeparate (minus64 $agenda.ActivationBlock $.BlockHeight)}} blocks). Ensure you are running a recent enough software version that supports the new rules. Visit our <a href="https://decred.org/downloads/" target="_blank">Downloads Page</a> to get the latest Software.</small>
-                    </p>
-                    </div>
-                {{end}}
-                {{if $agenda.IsActive}}
-                    <div class="agenda-voting-overview-disclaimer-activated">
-                    <p><small>The new rules have been activated. Ensure you are running a recent enough software version that supports the new rules. Visit our <a href="https://decred.org/downloads/" target="_blank">Downloads Page</a> to get the latest Software.</small>
-                    </p>
-                    </div>
-                {{end}}
+                  
+                  {{if $agenda.IsStarted}}
+                    Approximately <strong>{{blocksToTimeEstimate $agenda.EndHeight $.BlockHeight}}</strong> left for voting ({{commaSeparate (minus64 $agenda.EndHeight $.BlockHeight)}} blocks).
+                  {{end}}
+
+                  {{if $agenda.IsLockedIn}}
+                    The vote has passed! The new rules will be activated in approximately <strong>{{blocksToTimeEstimate $agenda.ActivationBlock $.BlockHeight}}</strong> ({{commaSeparate (minus64 $agenda.ActivationBlock $.BlockHeight)}} blocks). Ensure you are running a recent enough software version that supports the new rules. Visit our <a href="https://decred.org/downloads/" target="_blank">Downloads Page</a> to get the latest Software.
+                  {{end}}
+
+                  {{if $agenda.IsActive}}
+                    The new rules have been activated. Ensure you are running a recent enough software version that supports the new rules. Visit our <a href="https://decred.org/downloads/" target="_blank">Downloads Page</a> to get the latest Software.
+                  {{end}}
+                </small></p>
+                </div>
             </div>
           </div>
 

--- a/web.go
+++ b/web.go
@@ -15,11 +15,12 @@ import (
 )
 
 var funcMap = template.FuncMap{
-	"plus":             plus,
-	"minus":            minus,
-	"minus64":          minus64,
-	"commaSeparate":    commaSeparate,
-	"twoDecimalPlaces": twoDecimalPlaces,
+	"plus":                 plus,
+	"minus":                minus,
+	"minus64":              minus64,
+	"commaSeparate":        commaSeparate,
+	"twoDecimalPlaces":     twoDecimalPlaces,
+	"blocksToTimeEstimate": blocksToTimeEstimate,
 }
 
 func plus(a, b int) int {
@@ -122,7 +123,8 @@ func ceilDiv(numerator, denominator int64) int {
 
 // blocksToTimeEstimate returns a human-readable estimate for the amount of time
 // a given number of blocks would take.
-func blocksToTimeEstimate(blocksRemaining int64) string {
+func blocksToTimeEstimate(startHeight int64, currentHeight int64) string {
+	blocksRemaining := startHeight - currentHeight
 	remainingSecs := blocksRemaining * int64(activeNetParams.TargetTimePerBlock.Seconds())
 	if remainingSecs > hourCutoffSecs {
 		value := ceilDiv(remainingSecs, secondsPerDay)


### PR DESCRIPTION
- Fix the "Blocks remaining" style so it matches other disclaimer lines (Closes #247)
- Add a time estimate in days/hours/minutes as well as blocks remaining