### PR TITLE
More verbose description for treasury agenda

### DIFF
--- a/agenda.go
+++ b/agenda.go
@@ -196,10 +196,11 @@ func agendasFromJSON(getVoteInfo types.GetVoteInfoResult) []Agenda {
 			voteChoices[vote.ID] = vote
 		}
 		parsedAgendas = append(parsedAgendas, Agenda{
-			ID:              a.ID,
-			Status:          a.Status,
-			Title:           agendaTitles[a.ID],
-			Description:     a.Description,
+			ID:          a.ID,
+			Status:      a.Status,
+			Title:       agendaTitles[a.ID],
+			Description: a.Description,
+			// #nosec: this method will not auto-escape HTML. Verify data is well formed.
 			LongDescription: template.HTML(longAgendaDescriptions[a.ID]),
 			Mask:            a.Mask,
 			VoteVersion:     getVoteInfo.VoteVersion,

--- a/agenda.go
+++ b/agenda.go
@@ -18,9 +18,14 @@ import (
 // Agenda contains all of the data representing an agenda for the html
 // template programming.
 type Agenda struct {
-	ID              string
-	Status          string
-	Description     string
+	ID     string
+	Status string
+	// Title is the main heading for the agenda card, hard-coded in main.go.
+	Title string
+	// Description is the short description from dcrd GetVoteInfo RPC response.
+	Description string
+	// LongDescription is a more verbose description, hard-coded in main.go.
+	LongDescription template.HTML
 	Mask            uint16
 	VoteVersion     uint32
 	QuorumThreshold int64
@@ -193,7 +198,9 @@ func agendasFromJSON(getVoteInfo types.GetVoteInfoResult) []Agenda {
 		parsedAgendas = append(parsedAgendas, Agenda{
 			ID:              a.ID,
 			Status:          a.Status,
+			Title:           agendaTitles[a.ID],
 			Description:     a.Description,
+			LongDescription: template.HTML(longAgendaDescriptions[a.ID]),
 			Mask:            a.Mask,
 			VoteVersion:     getVoteInfo.VoteVersion,
 			QuorumThreshold: int64(getVoteInfo.Quorum),

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"html/template"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -45,7 +44,7 @@ var (
 	// parameters.
 	templateInformation *templateFields
 
-	friendlyAgendaLabels = map[string]string{
+	agendaTitles = map[string]string{
 		"sdiffalgorithm":    "Change PoS Staking Algorithm",
 		"lnsupport":         "Start Lightning Network Support",
 		"lnfeatures":        "Enable Lightning Network Features",
@@ -53,13 +52,13 @@ var (
 		"headercommitments": "Enable Block Header Commitments",
 		"treasury":          "Enable Decentralized Treasury",
 	}
-	longAgendaDescriptions = map[string]template.HTML{
-		"sdiffalgorithm":    template.HTML("Specifies a proposed replacement algorithm for determining the stake difficulty (commonly called the ticket price). This proposal resolves all issues with a new algorithm that adheres to the referenced ideals."),
-		"lnsupport":         template.HTML("The <a href='https://lightning.network/' target='_blank' rel='noopener noreferrer'>Lightning Network</a> is the most directly useful application of smart contracts to date since it allows for off-chain transactions that optionally settle on-chain. This infrastructure has clear benefits for both scaling and privacy. Decred is optimally positioned for this integration."),
-		"lnfeatures":        template.HTML("The <a href='https://lightning.network/' target='_blank' rel='noopener noreferrer'>Lightning Network</a> is the most directly useful application of smart contracts to date since it allows for off-chain transactions that optionally settle on-chain. This infrastructure has clear benefits for both scaling and privacy. Decred is optimally positioned for this integration."),
-		"fixlnseqlocks":     template.HTML("In order to fully support the <a href='https://lightning.network/' target='_blank' rel='noopener noreferrer'>Lightning Network</a>, the current sequence lock consensus rules need to be modified."),
-		"headercommitments": template.HTML("Proposed modifications to the Decred block header to increase the security and efficiency of lightweight clients, as well as adding infrastructure to enable future scalability enhancements."),
-		"treasury":          template.HTML("Proposed support for a decentralized treasury defined by <a href='https://github.com/decred/dcps/blob/master/dcp-0006/dcp-0006.mediawiki' target='_blank' rel='noopener noreferrer'>DCP0006</a>."),
+	longAgendaDescriptions = map[string]string{
+		"sdiffalgorithm":    "Specifies a proposed replacement algorithm for determining the stake difficulty (commonly called the ticket price). This proposal resolves all issues with a new algorithm that adheres to the referenced ideals.",
+		"lnsupport":         "The <a href='https://lightning.network/' target='_blank' rel='noopener noreferrer'>Lightning Network</a> is the most directly useful application of smart contracts to date since it allows for off-chain transactions that optionally settle on-chain. This infrastructure has clear benefits for both scaling and privacy. Decred is optimally positioned for this integration.",
+		"lnfeatures":        "The <a href='https://lightning.network/' target='_blank' rel='noopener noreferrer'>Lightning Network</a> is the most directly useful application of smart contracts to date since it allows for off-chain transactions that optionally settle on-chain. This infrastructure has clear benefits for both scaling and privacy. Decred is optimally positioned for this integration.",
+		"fixlnseqlocks":     "In order to fully support the <a href='https://lightning.network/' target='_blank' rel='noopener noreferrer'>Lightning Network</a>, the current sequence lock consensus rules need to be modified.",
+		"headercommitments": "Proposed modifications to the Decred block header to increase the security and efficiency of lightweight clients, as well as adding infrastructure to enable future scalability enhancements.",
+		"treasury":          "Proposed support for a decentralized treasury defined by <a href='https://github.com/decred/dcps/blob/master/dcp-0006/dcp-0006.mediawiki' target='_blank' rel='noopener noreferrer'>DCP0006</a>.",
 	}
 )
 
@@ -74,9 +73,6 @@ func updatetemplateInformation(ctx context.Context, dcrdClient *rpcclient.Client
 
 	// Set Current block height
 	templateInformation.BlockHeight = height
-
-	templateInformation.FriendlyAgendaLabels = friendlyAgendaLabels
-	templateInformation.LongAgendaDescriptions = longAgendaDescriptions
 
 	// Request GetStakeVersions to receive information about past block versions.
 	//

--- a/main.go
+++ b/main.go
@@ -58,13 +58,13 @@ var (
 		"lnfeatures":        "The <a href='https://lightning.network/' target='_blank' rel='noopener noreferrer'>Lightning Network</a> is the most directly useful application of smart contracts to date since it allows for off-chain transactions that optionally settle on-chain. This infrastructure has clear benefits for both scaling and privacy. Decred is optimally positioned for this integration.",
 		"fixlnseqlocks":     "In order to fully support the <a href='https://lightning.network/' target='_blank' rel='noopener noreferrer'>Lightning Network</a>, the current sequence lock consensus rules need to be modified.",
 		"headercommitments": "Proposed modifications to the Decred block header to increase the security and efficiency of lightweight clients, as well as adding infrastructure to enable future scalability enhancements.",
-		"treasury":          "Proposed support for a decentralized treasury defined by <a href='https://github.com/decred/dcps/blob/master/dcp-0006/dcp-0006.mediawiki' target='_blank' rel='noopener noreferrer'>DCP0006</a>.",
+		"treasury":          "In May 2019, Decred stakeholders approved the development of <a href='https://proposals.decred.org/proposals/c96290a' target='_blank' rel='noopener noreferrer'>a proposed solution</a> to further decentralize the process of spending from the Decred treasury.",
 	}
 )
 
 // updatetemplateInformation is called on startup and upon every block connected notification received.
 func updatetemplateInformation(ctx context.Context, dcrdClient *rpcclient.Client, latestBlockHeader *wire.BlockHeader) {
-	log.Println("updating vote information")
+	log.Println("Updating vote information")
 
 	hash := latestBlockHeader.BlockHash()
 	height := int64(latestBlockHeader.Height)
@@ -321,7 +321,7 @@ func mainCore() int {
 				log.Printf("Failed to deserialize block header: %v", errLocal)
 				return
 			}
-			log.Printf("received new block %v (height %d)", blockHeader.BlockHash(),
+			log.Printf("Received new block %v (height %d)", blockHeader.BlockHash(),
 				blockHeader.Height)
 			connectChan <- blockHeader
 		},

--- a/public/views/agenda-cards.html
+++ b/public/views/agenda-cards.html
@@ -1,11 +1,11 @@
 {{ define "agenda-cards" }}
 <div id="agendalisting" class="w-clearfix">
   
-  {{range $i, $agenda := .Agendas}}
+  {{range $agenda := .Agendas}}
   <div class="agenda drop-shadow w-clearfix" style="order: -{{$agenda.VoteVersion}};">
     <div class="agenda-section w-clearfix">
       <div class="agenda heading">
-        {{index $.FriendlyAgendaLabels $agenda.ID}}
+        {{$agenda.Title}}
       </div>
       <div class="agenda-indicator w-clearfix">
         <!-- labels -->
@@ -96,7 +96,7 @@
         </div>
         <div class="agenda-paragraph">
           <p style="font-weight: bold;">{{$agenda.DescriptionWithDCPURL}}</p>
-          <p>{{index $.LongAgendaDescriptions $agenda.ID}}</p>
+          <p>{{$agenda.LongDescription}}</p>
         </div>
       </div>
   

--- a/template_fields.go
+++ b/template_fields.go
@@ -5,8 +5,6 @@
 package main
 
 import (
-	"html/template"
-
 	"github.com/decred/dcrd/rpc/jsonrpc/types/v2"
 )
 
@@ -78,8 +76,4 @@ type templateFields struct {
 	PendingActivation bool
 	// Rules Activated to show that all rules have activated
 	RulesActivated bool
-	// Human friendly readable labels for each agenda
-	FriendlyAgendaLabels map[string]string
-	// Human friendly readable descriptions for each agenda
-	LongAgendaDescriptions map[string]template.HTML
 }


### PR DESCRIPTION
Previously the long description was just a slight rewording of the short description, introducing duplication and no extra information.

Also some refactoring for the handling of agenda titles & descriptions.
