### PR TITLE
Update to golangci-lint 1.40.1.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v2
       - name: Install Linters
-        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.38.0"
+        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.40.1"
       - name: Build
         env:
           GO111MODULE: "on"
@@ -24,4 +24,4 @@ jobs:
         env:
           GO111MODULE: "on"
         run: |
-          sh ./goclean.sh
+          ./run_tests.sh

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) 2015-2017, The Decred developers
+Copyright (c) 2015-2021, The Decred developers
 Copyright (c) 2017, Jonathan Chappelow
 
 Permission to use, copy, modify, and/or distribute this software for any

--- a/README.md
+++ b/README.md
@@ -12,12 +12,7 @@ information about consensus rule voting.
 
 ## Developing
 
-It is recommended to use Go 1.15 (or newer) for development:
-
-```no-highlight
-$ go version
-go version go1.15 linux/amd64
-```
+It is recommended to use Go 1.16 (or newer) for development.
 
 To build the code:
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -20,7 +20,7 @@ env GORACE="halt_on_error=1" go test -race ./...
 # check linters
 golangci-lint run --disable-all --deadline=10m \
   --enable=gofmt \
-  --enable=golint \
+  --enable=revive \
   --enable=vet \
   --enable=gosec \
   --enable=gosimple \


### PR DESCRIPTION
Linter `golint` has been deprecated and replaced with `revive`.